### PR TITLE
fix market resolution

### DIFF
--- a/contracts/src/Market.sol
+++ b/contracts/src/Market.sol
@@ -14,15 +14,23 @@ import "./RealityProxy.sol";
 contract Market {
     bool public initialized; // Flag to initialize the market only once
 
+    struct RealityParams {
+        bytes32[] questionsIds; // Reality questions ids
+        uint256 templateId; // Reality templateId
+        string[] encodedQuestions; // Encoded questions parameters, needed to create and reopen a question
+    }
+
+    struct ConditionalTokensParams {
+        bytes32 conditionId; // Conditional Tokens conditionId
+        bytes32 questionId; // Conditional Tokens questionId
+    }
+
     string public marketName; // The name of the market
     string[] public outcomes; // The market outcomes, doesn't include the INVALID_RESULT outcome
     uint256 public lowerBound; // Lower bound, only used for scalar markets
     uint256 public upperBound; // Upper bound, only user for scalar markets
-    bytes32 public conditionId; // Conditional Tokens conditionId
-    bytes32 public questionId; // Conditional Tokens questionId
-    bytes32[] public questionsIds; // Reality questions ids
-    uint256 public templateId; // Reality templateId
-    string[] public encodedQuestions; // Encoded questions parameters, needed to create and reopen a question
+    ConditionalTokensParams public conditionalTokensParams; // Conditional Tokens parameters
+    RealityParams public realityParams; // Reality parameters
     RealityProxy public realityProxy; // Oracle contract
 
     /// @dev Initializer
@@ -30,22 +38,16 @@ contract Market {
     /// @param _outcomes The market outcomes, doesn't include the INVALID_RESULT outcome
     /// @param _lowerBound Lower bound, only used for scalar markets
     /// @param _upperBound Upper bound, only user for scalar markets
-    /// @param _conditionId Conditional Tokens conditionId
-    /// @param _questionId Conditional Tokens questionId
-    /// @param _questionsIds Reality questions ids
-    /// @param _templateId Reality templateId
-    /// @param _encodedQuestions Encoded questions parameters, needed to create and reopen a question
+    /// @param _conditionalTokensParams Conditional Tokens params
+    /// @param _realityParams Reality params
     /// @param _realityProxy Oracle contract
     function initialize(
         string memory _marketName,
         string[] memory _outcomes,
         uint256 _lowerBound,
         uint256 _upperBound,
-        bytes32 _conditionId,
-        bytes32 _questionId,
-        bytes32[] memory _questionsIds,
-        uint256 _templateId,
-        string[] memory _encodedQuestions,
+        ConditionalTokensParams memory _conditionalTokensParams,
+        RealityParams memory _realityParams,
         RealityProxy _realityProxy
     ) external {
         require(!initialized, "Already initialized.");
@@ -54,20 +56,44 @@ contract Market {
         outcomes = _outcomes;
         lowerBound = _lowerBound;
         upperBound = _upperBound;
-        conditionId = _conditionId;
-        questionId = _questionId;
-        questionsIds = _questionsIds;
-        templateId = _templateId;
-        encodedQuestions = _encodedQuestions;
+        conditionalTokensParams = _conditionalTokensParams;
+        realityParams = _realityParams;
         realityProxy = _realityProxy;
 
         initialized = true;
     }
 
-    /// @dev Multi Scalar markets have one question for each outcome, while any other market has only one question.
-    /// @return questionsCount The number of Reality questions of this market
-    function getQuestionsCount() external view returns (uint256) {
-        return questionsIds.length;
+    /// @dev The templateId associated to the Reality question
+    function templateId() external view returns (uint256) {
+        return realityParams.templateId;
+    }
+
+    /// @dev Returns the Reality questions ids
+    function getQuestionsIds() external view returns (bytes32[] memory) {
+        return realityParams.questionsIds;
+    }
+
+    /// @dev Multi scalar markets have two or more questions, the other market types have 1
+    /// @return Array of question ids.
+    function questionsIds(uint256 index) external view returns (bytes32) {
+        return realityParams.questionsIds[index];
+    }
+
+    /// @dev Encoded questions parameters, needed to create and reopen a question
+    function encodedQuestions(
+        uint256 index
+    ) external view returns (string memory) {
+        return realityParams.encodedQuestions[index];
+    }
+
+    /// @dev Conditional Tokens questionId
+    function questionId() external view returns (bytes32) {
+        return conditionalTokensParams.questionId;
+    }
+
+    /// @dev Conditional Tokens conditionId
+    function conditionId() external view returns (bytes32) {
+        return conditionalTokensParams.conditionId;
     }
 
     /// @dev Returns the number of outcomes.

--- a/contracts/src/MarketFactory.sol
+++ b/contracts/src/MarketFactory.sol
@@ -36,9 +36,7 @@ contract MarketFactory {
 
     // Workaround "stack too deep" errors
     struct InternalMarketConfig {
-        bytes32 questionId; // Conditional Tokens questionId
-        bytes32[] questionsIds; // Reality questions ids
-        bytes32 conditionId; // Conditional Tokens conditionId
+        string[] encodedQuestions; // The encoded questions containing the Reality parameters
         uint256 outcomeSlotCount; // Conditional Tokens outcomeSlotCount
         uint256 templateId; // Reality templateId
     }
@@ -62,14 +60,9 @@ contract MarketFactory {
     event NewMarket(
         address indexed market,
         string marketName,
-        string[] outcomes,
-        uint256 lowerBound,
-        uint256 upperBound,
         bytes32 conditionId,
         bytes32 questionId,
-        bytes32[] questionsIds,
-        uint256 templateId,
-        string[] encodedQuestions
+        bytes32[] questionsIds
     );
 
     /**
@@ -123,26 +116,11 @@ contract MarketFactory {
             params.lang
         );
 
-        bytes32 questionId = askRealityQuestion(
-            encodedQuestions[0],
-            REALITY_SINGLE_SELECT_TEMPLATE,
-            params.openingTime,
-            params.minBond
-        );
-
-        bytes32 conditionId = prepareCondition(questionId, outcomeSlotCount);
-
-        bytes32[] memory questionsIds = new bytes32[](1);
-        questionsIds[0] = questionId;
-
         address marketId = createMarket(
             params,
             params.marketName,
-            encodedQuestions,
             InternalMarketConfig({
-                questionId: questionId,
-                questionsIds: questionsIds,
-                conditionId: conditionId,
+                encodedQuestions: encodedQuestions,
                 outcomeSlotCount: outcomeSlotCount,
                 templateId: REALITY_SINGLE_SELECT_TEMPLATE
             })
@@ -171,26 +149,11 @@ contract MarketFactory {
             params.lang
         );
 
-        bytes32 questionId = askRealityQuestion(
-            encodedQuestions[0],
-            REALITY_MULTI_SELECT_TEMPLATE,
-            params.openingTime,
-            params.minBond
-        );
-
-        bytes32 conditionId = prepareCondition(questionId, outcomeSlotCount);
-
-        bytes32[] memory questionsIds = new bytes32[](1);
-        questionsIds[0] = questionId;
-
         address marketId = createMarket(
             params,
             params.marketName,
-            encodedQuestions,
             InternalMarketConfig({
-                questionId: questionId,
-                questionsIds: questionsIds,
-                conditionId: conditionId,
+                encodedQuestions: encodedQuestions,
                 outcomeSlotCount: outcomeSlotCount,
                 templateId: REALITY_MULTI_SELECT_TEMPLATE
             })
@@ -224,26 +187,11 @@ contract MarketFactory {
             params.lang
         );
 
-        bytes32 questionId = askRealityQuestion(
-            encodedQuestions[0],
-            REALITY_UINT_TEMPLATE,
-            params.openingTime,
-            params.minBond
-        );
-
-        bytes32 conditionId = prepareCondition(questionId, outcomeSlotCount);
-
-        bytes32[] memory questionsIds = new bytes32[](1);
-        questionsIds[0] = questionId;
-
         address marketId = createMarket(
             params,
             params.marketName,
-            encodedQuestions,
             InternalMarketConfig({
-                questionId: questionId,
-                questionsIds: questionsIds,
-                conditionId: conditionId,
+                encodedQuestions: encodedQuestions,
                 outcomeSlotCount: outcomeSlotCount,
                 templateId: REALITY_UINT_TEMPLATE
             })
@@ -264,8 +212,6 @@ contract MarketFactory {
 
         uint256 outcomeSlotCount = params.outcomes.length + 1; // additional outcome for Invalid Result
 
-        bytes32[] memory questionsIds = new bytes32[](params.outcomes.length);
-
         string[] memory encodedQuestions = new string[](params.outcomes.length);
 
         for (uint256 i = 0; i < params.outcomes.length; i++) {
@@ -280,34 +226,21 @@ contract MarketFactory {
                 params.category,
                 params.lang
             );
-
-            questionsIds[i] = askRealityQuestion(
-                encodedQuestions[i],
-                REALITY_UINT_TEMPLATE,
-                params.openingTime,
-                params.minBond
-            );
         }
-        bytes32 questionId = keccak256(abi.encode(questionsIds));
-
-        bytes32 conditionId = prepareCondition(questionId, outcomeSlotCount);
 
         address marketId = createMarket(
             params,
             string(
                 abi.encodePacked(
                     params.questionStart,
-                    '[',
+                    "[",
                     params.outcomeType,
-                    ']',
+                    "]",
                     params.questionEnd
                 )
             ),
-            encodedQuestions,
             InternalMarketConfig({
-                questionId: questionId,
-                questionsIds: questionsIds,
-                conditionId: conditionId,
+                encodedQuestions: encodedQuestions,
                 outcomeSlotCount: outcomeSlotCount,
                 templateId: REALITY_UINT_TEMPLATE
             })
@@ -320,13 +253,42 @@ contract MarketFactory {
     function createMarket(
         CreateMarketParams memory params,
         string memory marketName,
-        string[] memory encodedQuestions,
         InternalMarketConfig memory config
     ) internal returns (address) {
         Market instance = Market(market.clone());
 
+        bytes32[] memory questionsIds = new bytes32[](
+            config.encodedQuestions.length
+        );
+
+        for (uint256 i = 0; i < config.encodedQuestions.length; i++) {
+            questionsIds[i] = askRealityQuestion(
+                config.encodedQuestions[i],
+                config.templateId,
+                params.openingTime,
+                params.minBond
+            );
+        }
+
+        // questionId must be a hash of all the values that RealityProxy.resolve() uses to resolve a market,
+        // this way if an attacker tries to resolve a fake market by changing some value
+        // its questionId will not match the id of a valid market
+        bytes32 questionId = keccak256(
+            abi.encode(
+                questionsIds,
+                config.outcomeSlotCount,
+                config.templateId,
+                params.lowerBound,
+                params.upperBound
+            )
+        );
+        bytes32 conditionId = prepareCondition(
+            questionId,
+            config.outcomeSlotCount
+        );
+
         deployERC20Positions(
-            config.conditionId,
+            conditionId,
             config.outcomeSlotCount,
             params.tokenNames
         );
@@ -335,25 +297,24 @@ contract MarketFactory {
             params.outcomes,
             params.lowerBound,
             params.upperBound,
-            config.conditionId,
-            config.questionId,
-            config.questionsIds,
-            config.templateId,
-            encodedQuestions,
+            Market.ConditionalTokensParams({
+                conditionId: conditionId,
+                questionId: questionId
+            }),
+            Market.RealityParams({
+                questionsIds: questionsIds,
+                templateId: config.templateId,
+                encodedQuestions: config.encodedQuestions
+            }),
             realityProxy
         );
 
         emit NewMarket(
             address(instance),
             marketName,
-            params.outcomes,
-            params.lowerBound,
-            params.upperBound,
-            config.conditionId,
-            config.questionId,
-            config.questionsIds,
-            config.templateId,
-            encodedQuestions
+            conditionId,
+            questionId,
+            questionsIds
         );
         markets.push(address(instance));
 

--- a/contracts/src/MarketView.sol
+++ b/contracts/src/MarketView.sol
@@ -199,14 +199,15 @@ contract MarketView {
             bytes32[] memory questionsIds
         )
     {
-        questions = new IRealityETH_v3_0.Question[](market.getQuestionsCount());
+        bytes32[] memory initialQuestionsIds = market.getQuestionsIds();
+        questions = new IRealityETH_v3_0.Question[](initialQuestionsIds.length);
         encodedQuestions = new string[](questions.length);
         questionsIds = new bytes32[](questions.length);
         {
             IRealityETH_v3_0 realitio = marketFactory.realitio();
             for (uint256 i = 0; i < questions.length; i++) {
                 questionsIds[i] = getQuestionId(
-                    market.questionsIds(i),
+                    initialQuestionsIds[i],
                     realitio
                 );
                 questions[i] = realitio.questions(questionsIds[i]);

--- a/contracts/test/MarketTest.sol
+++ b/contracts/test/MarketTest.sol
@@ -384,21 +384,17 @@ contract MarketFactoryTest is BaseTest {
         getMultiScalarMarket(MIN_BOND, 1);
     }
 
-    function test_revertsIfTriesToCreateTheSameMarket() public {
+    function test_canCreateRepeatedMarkets() public {
         getCategoricalMarket(MIN_BOND, 2);
-        vm.expectRevert(bytes("condition already prepared"));
         getCategoricalMarket(MIN_BOND, 2);
 
         getMultiCategoricalMarket(MIN_BOND, 2);
-        vm.expectRevert(bytes("condition already prepared"));
         getMultiCategoricalMarket(MIN_BOND, 2);
 
         getScalarMarket(MIN_BOND, 2);
-        vm.expectRevert(bytes("condition already prepared"));
         getScalarMarket(MIN_BOND, 2);
 
         getMultiScalarMarket(MIN_BOND, 2);
-        vm.expectRevert(bytes("condition already prepared"));
         getMultiScalarMarket(MIN_BOND, 2);
     }
 

--- a/contracts/test/hardhat/GnosisRouter.test.ts
+++ b/contracts/test/hardhat/GnosisRouter.test.ts
@@ -43,6 +43,7 @@ describe("GnosisRouter", function () {
     const marketAddress = (await marketFactory.allMarkets())[0];
     const market = await ethers.getContractAt("Market", marketAddress);
     const questionId = await market.questionId();
+    const questionsIds = await market.getQuestionsIds();
     const oracleAddress = await realityProxy.getAddress();
     const conditionId = await conditionalTokens.getConditionId(oracleAddress, questionId, outcomeSlotCount);
     const partition = Array(outcomeSlotCount)
@@ -56,7 +57,7 @@ describe("GnosisRouter", function () {
     await gnosisRouter.splitFromBase(PARENT_COLLECTION_ID, conditionId, partition, {
       value: ethers.parseEther(SPLIT_AMOUNT),
     });
-    return { outcomeSlotCount, conditionId, questionId, market };
+    return { outcomeSlotCount, conditionId, questionsIds, market };
   }
 
   beforeEach(async function () {
@@ -175,14 +176,14 @@ describe("GnosisRouter", function () {
       const [owner] = await ethers.getSigners();
       const amountInSDai = await sDAI.convertToShares(ethers.parseEther(SPLIT_AMOUNT));
       // split first
-      const { outcomeSlotCount, conditionId, questionId, market } = await createMarketAndSplitPosition();
+      const { outcomeSlotCount, conditionId, questionsIds, market } = await createMarketAndSplitPosition();
 
       // answer the question and resolve the market
       // past opening_ts
       await time.increase(OPENING_TS);
 
       // submit answer
-      await realitio.submitAnswer(questionId, ethers.toBeHex(BigInt(ANSWER), 32), 0, {
+      await realitio.submitAnswer(questionsIds[0], ethers.toBeHex(BigInt(ANSWER), 32), 0, {
         value: ethers.parseEther(MIN_BOND),
       });
 
@@ -245,13 +246,13 @@ describe("GnosisRouter", function () {
       const [owner] = await ethers.getSigners();
       const amountInSDai = await sDAI.convertToShares(ethers.parseEther(SPLIT_AMOUNT));
       // split first
-      const { outcomeSlotCount, conditionId, questionId, market } = await createMarketAndSplitPosition();
+      const { outcomeSlotCount, conditionId, questionsIds, market } = await createMarketAndSplitPosition();
 
       // answer the question and resolve the market
       // past opening_ts
       await time.increase(OPENING_TS);
       // submit answer
-      await realitio.submitAnswer(questionId, ethers.toBeHex(BigInt(ANSWER), 32), 0, {
+      await realitio.submitAnswer(questionsIds[0], ethers.toBeHex(BigInt(ANSWER), 32), 0, {
         value: ethers.parseEther(MIN_BOND),
       });
 

--- a/contracts/test/hardhat/MainnetRouter.test.ts
+++ b/contracts/test/hardhat/MainnetRouter.test.ts
@@ -49,6 +49,7 @@ describe("MainnetRouter", function () {
     const marketAddress = (await marketFactory.allMarkets())[0];
     const market = await ethers.getContractAt("Market", marketAddress);
     const questionId = await market.questionId();
+    const questionsIds = await market.getQuestionsIds();
     const oracleAddress = await realityProxy.getAddress();
     const conditionId = await conditionalTokens.getConditionId(oracleAddress, questionId, outcomeSlotCount);
     const partition = Array(outcomeSlotCount)
@@ -59,7 +60,7 @@ describe("MainnetRouter", function () {
     await DAI.approve(mainnetRouter, ethers.parseEther(SPLIT_AMOUNT));
     // split collateral token to outcome tokens
     await mainnetRouter.splitFromDai(PARENT_COLLECTION_ID, conditionId, partition, ethers.parseEther(SPLIT_AMOUNT));
-    return { outcomeSlotCount, conditionId, questionId, market };
+    return { outcomeSlotCount, conditionId, questionsIds, market };
   }
 
   beforeEach(async function () {
@@ -206,14 +207,14 @@ describe("MainnetRouter", function () {
       const ANSWER = 1;
       const REDEEMED_POSITION = 1;
       // split first
-      const { outcomeSlotCount, conditionId, questionId, market } = await createMarketAndSplitPosition();
+      const { outcomeSlotCount, conditionId, questionsIds, market } = await createMarketAndSplitPosition();
       const amountInSDai = await sDAI.convertToShares(ethers.parseEther(SPLIT_AMOUNT));
       // answer the question and resolve the market
       // past opening_ts
       await time.increase(OPENING_TS);
 
       // submit answer
-      await realitio.submitAnswer(questionId, ethers.toBeHex(BigInt(ANSWER), 32), 0, {
+      await realitio.submitAnswer(questionsIds[0], ethers.toBeHex(BigInt(ANSWER), 32), 0, {
         value: ethers.parseEther(MIN_BOND),
       });
 
@@ -269,13 +270,13 @@ describe("MainnetRouter", function () {
       const REDEEMED_POSITION = 0;
 
       // split first
-      const { outcomeSlotCount, conditionId, questionId, market } = await createMarketAndSplitPosition();
+      const { outcomeSlotCount, conditionId, questionsIds, market } = await createMarketAndSplitPosition();
       const amountInSDai = await sDAI.convertToShares(ethers.parseEther(SPLIT_AMOUNT));
       // answer the question and resolve the market
       // past opening_ts
       await time.increase(OPENING_TS);
       // submit answer
-      await realitio.submitAnswer(questionId, ethers.toBeHex(BigInt(ANSWER), 32), 0, {
+      await realitio.submitAnswer(questionsIds[0], ethers.toBeHex(BigInt(ANSWER), 32), 0, {
         value: ethers.parseEther(MIN_BOND),
       });
 

--- a/contracts/test/hardhat/Market.test.ts
+++ b/contracts/test/hardhat/Market.test.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { ethers, network } from "hardhat";
 import { Market, RealityProxy } from "../../typechain-types";
 import { HardhatEthersSigner } from "@nomicfoundation/hardhat-ethers/signers";
+import { getQuestionId } from "./helpers/utils";
 
 describe("Market", function () {
   let market: Market;
@@ -27,7 +28,6 @@ describe("Market", function () {
       const lowerBound = 0;
       const upperBound = 100;
       const conditionId = ethers.hexlify(ethers.randomBytes(32));
-      const questionId = ethers.hexlify(ethers.randomBytes(32));
       const questionsIds = [
         ethers.hexlify(ethers.randomBytes(32)),
         ethers.hexlify(ethers.randomBytes(32)),
@@ -35,16 +35,22 @@ describe("Market", function () {
       const templateId = 1;
       const encodedQuestions = ["encoded1", "encoded2"];
 
+      const questionId = getQuestionId(questionsIds, outcomes.length + 1, templateId, lowerBound, upperBound);
+
       await market.initialize(
         marketName,
         outcomes,
         lowerBound,
         upperBound,
-        conditionId,
-        questionId,
-        questionsIds,
-        templateId,
-        encodedQuestions,
+        {
+          conditionId,
+          questionId,
+        },
+        {
+          questionsIds,
+          templateId,
+          encodedQuestions
+        },
         realityProxy
       );
 
@@ -70,11 +76,17 @@ describe("Market", function () {
         ["Outcome1"],
         0,
         100,
-        ethers.hexlify(ethers.randomBytes(32)),
-        ethers.hexlify(ethers.randomBytes(32)),
-        [ethers.hexlify(ethers.randomBytes(32))],
-        1,
-        ["encoded1"],
+        {
+          conditionId: ethers.hexlify(ethers.randomBytes(32)),
+          questionId: ethers.hexlify(ethers.randomBytes(32)),
+        },
+        {
+          questionsIds: [
+            ethers.hexlify(ethers.randomBytes(32)),
+          ],
+          templateId: 1,
+          encodedQuestions: ["encoded1"]
+        },
         realityProxy
       );
 
@@ -84,11 +96,17 @@ describe("Market", function () {
           ["Outcome2"],
           0,
           100,
-          ethers.hexlify(ethers.randomBytes(32)),
-          ethers.hexlify(ethers.randomBytes(32)),
-          [ethers.hexlify(ethers.randomBytes(32))],
-          2,
-          ["encoded2"],
+          {
+            conditionId: ethers.hexlify(ethers.randomBytes(32)),
+            questionId: ethers.hexlify(ethers.randomBytes(32)),
+          },
+          {
+            questionsIds: [
+              ethers.hexlify(ethers.randomBytes(32)),
+            ],
+            templateId: 1,
+            encodedQuestions: ["encoded2"]
+          },
           realityProxy
         )
       ).to.be.revertedWith("Already initialized.");
@@ -102,20 +120,20 @@ describe("Market", function () {
         ["Outcome1", "Outcome2", "Outcome3"],
         0,
         100,
-        ethers.hexlify(ethers.randomBytes(32)),
-        ethers.hexlify(ethers.randomBytes(32)),
-        [
-          ethers.hexlify(ethers.randomBytes(32)),
-          ethers.hexlify(ethers.randomBytes(32)),
-        ],
-        1,
-        ["encoded1", "encoded2"],
+        {
+          conditionId: ethers.hexlify(ethers.randomBytes(32)),
+          questionId: ethers.hexlify(ethers.randomBytes(32)),
+        },
+        {
+          questionsIds: [
+            ethers.hexlify(ethers.randomBytes(32)),
+            ethers.hexlify(ethers.randomBytes(32)),
+          ],
+          templateId: 1,
+          encodedQuestions: ["encoded1", "encoded2"]
+        },
         realityProxy
       );
-    });
-
-    it("returns the correct number of questions", async function () {
-      expect(await market.getQuestionsCount()).to.equal(2);
     });
 
     it("returns the correct number of outcomes", async function () {

--- a/contracts/test/hardhat/MarketFactory.test.ts
+++ b/contracts/test/hardhat/MarketFactory.test.ts
@@ -85,7 +85,7 @@ describe("MarketFactory", function () {
       await marketFactory.createCategoricalMarket(categoricalMarketParams);
       const marketAddress = (await marketFactory.allMarkets())[0];
       const market = await ethers.getContractAt("Market", marketAddress);
-      expect(questionId).to.equal(await market.questionId());
+      expect(questionId).to.equal(await market.questionsIds(0));
     });
     it("creates a categorical market", async function () {
       await expect(
@@ -95,14 +95,9 @@ describe("MarketFactory", function () {
         .withArgs(
           ethers.isAddress,
           categoricalMarketParams.marketName,
-          categoricalMarketParams.outcomes,
-          categoricalMarketParams.lowerBound,
-          categoricalMarketParams.upperBound,
           ethers.isHexString,
           ethers.isHexString,
           [ethers.isHexString],
-          ethers.getBigInt(2),
-          categoricalMarketParams.encodedQuestions
         );
       const marketCount = Number(await marketFactory.marketCount());
       expect(marketCount).to.equal(1);
@@ -126,14 +121,9 @@ describe("MarketFactory", function () {
         .withArgs(
           ethers.isAddress,
           multiCategoricalMarketParams.marketName,
-          multiCategoricalMarketParams.outcomes,
-          multiCategoricalMarketParams.lowerBound,
-          multiCategoricalMarketParams.upperBound,
           ethers.isHexString,
           ethers.isHexString,
           [ethers.isHexString],
-          ethers.getBigInt(3),
-          multiCategoricalMarketParams.encodedQuestions
         );
 
       const marketCount = Number(await marketFactory.marketCount());
@@ -181,14 +171,9 @@ describe("MarketFactory", function () {
         .withArgs(
           ethers.isAddress,
           scalarMarketParams.marketName,
-          scalarMarketParams.outcomes,
-          scalarMarketParams.lowerBound,
-          scalarMarketParams.upperBound,
           ethers.isHexString,
           ethers.isHexString,
           [ethers.isHexString],
-          ethers.getBigInt(1),
-          scalarMarketParams.encodedQuestions
         );
 
       const marketCount = Number(await marketFactory.marketCount());
@@ -213,16 +198,11 @@ describe("MarketFactory", function () {
         .withArgs(
           ethers.isAddress,
           multiScalarMarketParams.marketName,
-          multiScalarMarketParams.outcomes,
-          multiScalarMarketParams.lowerBound,
-          multiScalarMarketParams.upperBound,
           ethers.isHexString,
           ethers.isHexString,
           multiScalarMarketParams.encodedQuestions.map(
             () => ethers.isHexString
           ),
-          ethers.getBigInt(1),
-          multiScalarMarketParams.encodedQuestions
         );
 
       const marketCount = Number(await marketFactory.marketCount());

--- a/contracts/test/hardhat/MarketFactory.test.ts
+++ b/contracts/test/hardhat/MarketFactory.test.ts
@@ -218,11 +218,9 @@ describe("MarketFactory", function () {
       }
       expect(await marketFactory.marketCount()).to.equal(MARKET_COUNT);
     });
-    it("reverts if try to create multiple multi-scalar markets with same params", async function () {
+    it("allows to create multiple multi-scalar markets with same params", async function () {
       await marketFactory.createMultiScalarMarket(multiScalarMarketParams);
-      await expect(
-        marketFactory.createMultiScalarMarket(multiScalarMarketParams)
-      ).to.be.reverted;
+      await marketFactory.createMultiScalarMarket(multiScalarMarketParams);
     });
   });
 

--- a/contracts/test/hardhat/MarketView.test.ts
+++ b/contracts/test/hardhat/MarketView.test.ts
@@ -129,7 +129,7 @@ describe("MarketView", function () {
         });
         const marketAddress = (await marketFactory.allMarkets())[0];
         const market = await ethers.getContractAt("Market", marketAddress);
-        questionId = await market.questionId();
+        questionId = await market.questionsIds(0);
         templateId = await market.templateId();
 
         // past opening_ts

--- a/contracts/test/hardhat/RealityProxy.test.ts
+++ b/contracts/test/hardhat/RealityProxy.test.ts
@@ -62,7 +62,7 @@ describe("RealityProxy", function () {
         await time.increase(OPENING_TS);
         // submit answer
         await realitio.submitAnswer(
-          questionId,
+          await market.questionsIds(0),
           ethers.toBeHex(BigInt(answer), 32),
           0,
           {
@@ -143,7 +143,7 @@ describe("RealityProxy", function () {
         await time.increase(OPENING_TS);
         // submit answer
         await realitio.submitAnswer(
-          questionId,
+          await market.questionsIds(0),
           ethers.toBeHex(BigInt(answer), 32),
           0,
           {
@@ -235,7 +235,7 @@ describe("RealityProxy", function () {
         await time.increase(OPENING_TS);
         // submit answer
         await realitio.submitAnswer(
-          questionId,
+          await market.questionsIds(0),
           ethers.toBeHex(BigInt(answer), 32),
           0,
           {
@@ -320,15 +320,14 @@ describe("RealityProxy", function () {
           questionId,
           multiScalarMarketParams.outcomes.length + 1
         );
-        const realityQuestionCount = await market.getQuestionsCount();
+        const questionsIds = await market.getQuestionsIds();
 
         // past opening_ts
         await time.increase(OPENING_TS);
         // submit answers
-        for (let i = 0; i < realityQuestionCount; i++) {
-          const realityQuestionId = await market.questionsIds(i);
+        for (let i = 0; i < questionsIds.length; i++) {
           await realitio.submitAnswer(
-            realityQuestionId,
+            questionsIds[i],
             ethers.toBeHex(BigInt(answers[i]), 32),
             0,
             {

--- a/contracts/test/hardhat/Router.test.ts
+++ b/contracts/test/hardhat/Router.test.ts
@@ -44,6 +44,7 @@ describe("Router", function () {
     const marketAddress = (await marketFactory.allMarkets())[0];
     const market = await ethers.getContractAt("Market", marketAddress);
     const questionId = await market.questionId();
+    const questionsIds = await market.getQuestionsIds();
     const oracleAddress = await realityProxy.getAddress();
     const conditionId = await conditionalTokens.getConditionId(
       oracleAddress,
@@ -64,7 +65,7 @@ describe("Router", function () {
         .map((_, index) => getBitMaskDecimal([index], outcomeSlotCount)),
       ethers.parseEther(SPLIT_AMOUNT)
     );
-    return { outcomeSlotCount, conditionId, questionId, market };
+    return { outcomeSlotCount, conditionId, questionsIds, market };
   }
 
   beforeEach(async function () {
@@ -191,7 +192,7 @@ describe("Router", function () {
       const REDEEMED_POSITION = 1;
       const [owner] = await ethers.getSigners();
       // split first
-      const { outcomeSlotCount, conditionId, questionId, market } =
+      const { outcomeSlotCount, conditionId, questionsIds, market } =
         await createMarketAndSplitPosition();
 
       // answer the question and resolve the market
@@ -199,7 +200,7 @@ describe("Router", function () {
       await time.increase(OPENING_TS);
       // submit answer
       await realitio.submitAnswer(
-        questionId,
+        questionsIds[0],
         ethers.toBeHex(BigInt(ANSWER), 32),
         0,
         {
@@ -272,7 +273,7 @@ describe("Router", function () {
       const REDEEMED_POSITION = 0;
       const [owner] = await ethers.getSigners();
       // split first
-      const { outcomeSlotCount, conditionId, questionId, market } =
+      const { outcomeSlotCount, conditionId, questionsIds, market } =
         await createMarketAndSplitPosition();
 
       // answer the question and resolve the market
@@ -280,7 +281,7 @@ describe("Router", function () {
       await time.increase(OPENING_TS);
       // submit answer
       await realitio.submitAnswer(
-        questionId,
+        questionsIds[0],
         ethers.toBeHex(BigInt(ANSWER), 32),
         0,
         {

--- a/contracts/test/hardhat/helpers/utils.ts
+++ b/contracts/test/hardhat/helpers/utils.ts
@@ -71,3 +71,12 @@ export function generateSentences(sentenceCount: number, wordCount: number) {
 
   return sentences;
 }
+
+export function getQuestionId(questionsIds: string[], outcomeSlotCount: number, templateId: number, lowerBound: number, upperBound: number) {
+  return ethers.keccak256(
+    ethers.AbiCoder.defaultAbiCoder().encode(
+      ['bytes32[]', 'uint256', 'uint256', 'uint256', 'uint256'],
+      [questionsIds, outcomeSlotCount, templateId, lowerBound, upperBound]
+    )
+  );
+}


### PR DESCRIPTION
Fix 1:

RealityProxy.sol:
* refactor the internal functions to receive the values needed (questionId, numOutcomes, etc) instead of receiving the Market. The Market is only used on resolve(), where we build the questionId based on the other values to prevent a fake market from being able to report a payout.

MarketFactory.sol: 
* now the questionId is calculated as `keccak256( abi.encode(questionsIds, outcomeSlotCount, templateId, low, high) )`. questionId, questionsIds and conditionId can be calculated from the encodedQuestions, so I removed this from the 4 factory functions and moved it to the main createMarket function. I also removed some unused parameters from the NewMarket event to avoid a stack too deep error (this same change was made on the conditional markets PR)

Market.sol: 
* grouped the reality and conditional tokens parameters in a struct to avoid a stack too deep error on the market factory (this same change was made on the conditional markets PR)

Fix 2:

MarketFactory.sol: 
* we call conditionalTokens.prepareCondition() only if the condition hasn't already been prepared. Until now the assumption was that the same market couldn't be created twice, but now that we allow the reuse of an existing conditionId it's possible to duplicate a market (we could try to avoid it, but I think the extra complexity is not worth it)