### PR TITLE
fix: create market => create

### DIFF
--- a/web/src/components/Layout/Header.tsx
+++ b/web/src/components/Layout/Header.tsx
@@ -56,7 +56,7 @@ export default function Header() {
             <Link to={"/"}>Markets</Link>
           </li>
           <li>
-            <Link to={"/create-market"}>Create Market</Link>
+            <Link to={"/create-market"}>Create</Link>
           </li>
           <li>
             <div className="dropdown dropdown-end">
@@ -208,7 +208,7 @@ function MobileMenu() {
             <Link to={"/"}>Markets</Link>
           </li>
           <li>
-            <Link to={"/create-market"}>Create Market</Link>
+            <Link to={"/create-market"}>Create</Link>
           </li>
         </ul>
 


### PR DESCRIPTION
makes m1 screens render better not
overlap, should be clear naming
close #60

(cannot test)