### PR TITLE
feat: preselect fee 0.3% on bunni add liquidity

### DIFF
--- a/web/src/lib/config.ts
+++ b/web/src/lib/config.ts
@@ -88,7 +88,7 @@ export const getLiquidityUrl = (chainId: number, token1: string, token2: string)
     case gnosis.id:
       return `https://v3.swapr.eth.limo/#/add/${token1}/${token2}/enter-amounts`;
     case mainnet.id:
-      return `https://bunni.pro/add/ethereum?tokenA=${token1}&tokenB=${token2}`;
+      return `https://bunni.pro/add/ethereum?tokenA=${token1}&tokenB=${token2}&fee=3000`;
     default:
       return "#";
   }


### PR DESCRIPTION
preopens the tab on 0.3% swap fee pool,
which is the one that was selected on the
main market. user can still change it, its just
set as a default

this would be how it looks after clicking on it (saves a click) and prevents users from unintendedly spending a ton of gas creating a new pool

<img width="1223" alt="image" src="https://github.com/user-attachments/assets/579a7215-0d35-408d-b8f2-bd3c76aac589">

Looked to do this in swapr but it seems its not supported

If you feel like it you can slightly edit this to pass the fee as a parameter, although maybe do that in a future version is better to ship faster?