### PR TITLE
fix: expected shares shimmer instead of 0

### DIFF
--- a/web/src/components/Market/SwapTokens.tsx
+++ b/web/src/components/Market/SwapTokens.tsx
@@ -294,7 +294,7 @@ export function SwapTokens({
             <div className="flex space-x-2 text-purple-primary">
               {swapType === "buy" ? "Expected shares" : "Expected amount"} ={" "}
               {quoteFetchStatus === "fetching"
-                ? <div className="shimmer-container ml-2 w-24"/>
+                ? <div className="shimmer-container ml-2 flex-grow"/>
                 : swapType === "sell" && isSellToOtherCollateral ? assets : shares
               }
             </div>

--- a/web/src/components/Market/SwapTokens.tsx
+++ b/web/src/components/Market/SwapTokens.tsx
@@ -189,7 +189,7 @@ export function SwapTokens({
     : Number(formatUnits(maxDAIPerShare ?? 0n, selectedCollateral.decimals));
   const collateralPerShare = Number(amount) / Number(shares);
   const isPriceTooHigh = Number(shares) > 0 && collateralPerShare > maxCollateralPerShare && swapType === "buy";
-
+  
   return (
     <>
       <ConfirmSwapModal
@@ -293,7 +293,10 @@ export function SwapTokens({
 
             <div className="flex space-x-2 text-purple-primary">
               {swapType === "buy" ? "Expected shares" : "Expected amount"} ={" "}
-              {swapType === "sell" && isSellToOtherCollateral ? assets : shares}
+              {quoteFetchStatus === "fetching"
+                ? <div className="shimmer-container ml-2 w-24"/>
+                : swapType === "sell" && isSellToOtherCollateral ? assets : shares
+              }
             </div>
 
             {isPriceTooHigh && (


### PR DESCRIPTION

It was showing 0 before which shouldnt be rendered

<img width="337" alt="image" src="https://github.com/user-attachments/assets/66635338-cf68-432c-8052-9dbd11782fcb">
