### PR TITLE
fix: make max slippage options responsive in form.

### DIFF
--- a/web/src/components/Market/SwapTokensMaxSlippage.tsx
+++ b/web/src/components/Market/SwapTokensMaxSlippage.tsx
@@ -49,7 +49,7 @@ export default function SwapTokensMaxSlippage({ onReturn }: { onReturn: () => vo
           <QuestionIcon fill="#9747FF" />
         </div>
       </div>
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         {MAX_SLIPPAGE_OPTIONS.map((option) => (
           <div
             key={option.value}


### PR DESCRIPTION
I fixed the options to ensure they are responsive on smaller laptop screens, as my screen is also small.

![Screenshot 2024-10-09 191939](https://github.com/user-attachments/assets/8d38ea2d-4215-49b1-8439-24d0a5eb452a)
