### PR TITLE
fix: make MarketAnswers responsive in card

### DIFF
--- a/web/src/components/Market/Header/QuestionLine.tsx
+++ b/web/src/components/Market/Header/QuestionLine.tsx
@@ -187,7 +187,7 @@ export function QuestionLine({
 
   if (questionStatus === MarketStatus.IN_DISPUTE) {
     return (
-      <div className={clsx("flex items-center space-x-[12px]", COLORS[questionStatus]?.text)}>
+      <div className={clsx("flex flex-wrap items-center space-x-[12px]", COLORS[questionStatus]?.text)}>
         <AnswerColumn {...{ marketStatus, marketType, question, questionStatus, questionIndex, market, isPreview }} />
 
         <div className="text-black-medium">|</div>
@@ -206,7 +206,7 @@ export function QuestionLine({
     return (
       <div
         className={clsx(
-          "flex items-center space-x-[12px]",
+          "flex flex-wrap items-center space-x-[12px]",
           isQuestionFinalized ? "text-success-primary" : COLORS[questionStatus]?.text,
           isPreviewWithMultiQuestions && "flex-wrap",
         )}
@@ -247,7 +247,7 @@ export function QuestionLine({
   return (
     <div
       className={clsx(
-        "flex items-center space-x-[12px]",
+        "flex flex-wrap items-center space-x-[12px]",
         COLORS[marketStatus === MarketStatus.PENDING_EXECUTION ? MarketStatus.PENDING_EXECUTION : questionStatus]?.text,
       )}
     >


### PR DESCRIPTION
That kind of section is not responsive on smaller screens, like phones.

![86fc741f-ed53-4e2f-8531-c009a9041265](https://github.com/user-attachments/assets/58f262f1-9578-4f89-b197-d45780f6b9a8)
