### PR TITLE
adding link to RighArrow icon

### DIFF
--- a/web/src/components/Market/Header/QuestionLine.tsx
+++ b/web/src/components/Market/Header/QuestionLine.tsx
@@ -55,10 +55,11 @@ function AnswerColumn({
 function RealityLink({ chainId, questionId }: { chainId: SupportedChain; questionId: `0x${string}` }) {
   return (
     <>
-      <a className="text-purple-primary" href={getRealityLink(chainId, questionId)} target="_blank" rel="noreferrer">
+      <a className="text-purple-primary flex items-center" href={getRealityLink(chainId, questionId)} target="_blank" rel="noreferrer">
         Check it on Reality.eth
+        <span className="ml-2"> <RightArrow /></span>
       </a>
-      <RightArrow />
+     
     </>
   );
 }
@@ -75,14 +76,14 @@ function DisputeLink({ questionId, chainId }: { questionId: `0x${string}`; chain
   return (
     <div className="flex items-center space-x-2">
       <a
-        className="text-purple-primary"
+        className="text-purple-primary flex items-center"
         href={paths.klerosDispute(disputeId, mainnet.id)}
         target="_blank"
         rel="noreferrer"
       >
         Check the case on Kleros Court
+        <span className="ml-2"> <RightArrow /></span>
       </a>
-      <RightArrow />
     </div>
   );
 }
@@ -177,10 +178,10 @@ export function QuestionLine({
             <div className="text-black-medium">|</div>
           </>
         )}
-        <button type="button" className="text-purple-primary" onClick={() => openAnswerModal(question)}>
-          Answer on Reality.eth!
+        <button type="button" className="text-purple-primary flex items-center" onClick={() => openAnswerModal(question)}>
+          Answer on Reality.eth! 
+          <span className="ml-2"> <RightArrow /></span>
         </button>
-        <RightArrow />
       </div>
     );
   }


### PR DESCRIPTION
It’s strange for users when the right arrow icon cannot be clicked or lacks a link. So, I added that icon into an <a> tag.

![Screenshot 2024-10-10 224504](https://github.com/user-attachments/assets/31cf7661-77a8-4bcc-a830-659d379e124e)
