### PR TITLE
fix(responsive): prevent handover icon overflow on smaller screens

### DIFF
--- a/web/src/components/Market/AnswerForm.tsx
+++ b/web/src/components/Market/AnswerForm.tsx
@@ -127,7 +127,7 @@ export function AnswerForm({ market, marketStatus, question, closeModal, raiseDi
     return (
       <>
         <Alert type="error">Connect your wallet to submit an answer.</Alert>
-        <div className="space-x-[24px] text-center mt-[24px]">
+        <div className="space-x-[24px] text-center mt-[24px] flex justify-center">
           <Button type="button" variant="secondary" text="Return" onClick={closeModal} />
           <Button variant="primary" type="button" onClick={async () => open({ view: "Connect" })} text="Connect" />
         </div>

--- a/web/src/components/Market/Header/MarketHeader.tsx
+++ b/web/src/components/Market/Header/MarketHeader.tsx
@@ -234,7 +234,7 @@ export function MarketHeader({
           <div className="flex items-center gap-2">Market Estimate: {isPendingOdds ? <Spinner /> : marketEstimate}</div>
           {!isPendingOdds && (
             <span className="tooltip">
-              <p className="tooltiptext !whitespace-pre-wrap w-[300px] md:[400px] ">
+              <p className="tooltiptext !whitespace-pre-wrap w-[300px] md:w[400px] ">
                 The market's predicted result based on the current distribution of "UP" and "DOWN" tokens
               </p>
               <QuestionIcon fill="#9747FF" />

--- a/web/src/components/Market/Header/MarketHeader.tsx
+++ b/web/src/components/Market/Header/MarketHeader.tsx
@@ -234,7 +234,7 @@ export function MarketHeader({
           <div className="flex items-center gap-2">Market Estimate: {isPendingOdds ? <Spinner /> : marketEstimate}</div>
           {!isPendingOdds && (
             <span className="tooltip">
-              <p className="tooltiptext !whitespace-pre-wrap w-[400px]">
+              <p className="tooltiptext !whitespace-pre-wrap w-[300px] md:[400px] ">
                 The market's predicted result based on the current distribution of "UP" and "DOWN" tokens
               </p>
               <QuestionIcon fill="#9747FF" />

--- a/web/src/components/Market/Header/MarketHeader.tsx
+++ b/web/src/components/Market/Header/MarketHeader.tsx
@@ -234,7 +234,7 @@ export function MarketHeader({
           <div className="flex items-center gap-2">Market Estimate: {isPendingOdds ? <Spinner /> : marketEstimate}</div>
           {!isPendingOdds && (
             <span className="tooltip">
-              <p className="tooltiptext !whitespace-pre-wrap w-[300px] md:w[400px] ">
+              <p className="tooltiptext !whitespace-pre-wrap w-[250px] md:w[400px] ">
                 The market's predicted result based on the current distribution of "UP" and "DOWN" tokens
               </p>
               <QuestionIcon fill="#9747FF" />

--- a/web/src/components/Market/Outcomes.tsx
+++ b/web/src/components/Market/Outcomes.tsx
@@ -289,7 +289,7 @@ export function Outcomes({ chainId, market, images, tradeCallback }: PositionsPr
                     </p>
                     {getMarketType(market) === MarketTypes.SCALAR && i !== market.wrappedTokens.length - 1 && (
                       <span className="tooltip">
-                        <p className="tooltiptext !whitespace-pre-wrap w-[400px] !text-left">
+                        <p className="tooltiptext !whitespace-pre-wrap w-[250px] md:w-[400px] !text-left">
                           {getTooltipContent(market, i)}
                         </p>
                         <QuestionIcon fill="#9747FF" />

--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -268,6 +268,10 @@
   z-index: 2;
   font-size: 14px;
   white-space: nowrap;
+
+  @media (max-width: 1024px) { /* For screens smaller than 640px (sm breakpoint) */
+    white-space: normal;
+   }
 }
 
 .tooltip .tooltiptext::after {

--- a/web/src/index.scss
+++ b/web/src/index.scss
@@ -269,7 +269,7 @@
   font-size: 14px;
   white-space: nowrap;
 
-  @media (max-width: 1024px) { /* For screens smaller than 640px (sm breakpoint) */
+  @media (max-width: 1024px) { /* For screens smaller than 1024px (md breakpoint) */
     white-space: normal;
    }
 }


### PR DESCRIPTION
When I looked at it on a phone, some elements were overflowing on the smaller screen, so I fixed that.


![Screenshot 2024-10-15 232352](https://github.com/user-attachments/assets/55d6d88e-e6a6-4244-a98f-10ab2ce91495)
![Screenshot 2024-10-15 232431](https://github.com/user-attachments/assets/a48d34df-1b7d-4cc9-b469-ce2811c24a34)
![Screenshot 2024-10-15 232508](https://github.com/user-attachments/assets/d78c2a3a-0bd7-45b6-99b4-79ec7a089237)
