### PR TITLE
Fix: telegramLink

### DIFF
--- a/web/src/lib/paths.ts
+++ b/web/src/lib/paths.ts
@@ -36,6 +36,6 @@ export const paths = {
   snapshot: () => "#",
   discord: () => "#",
   twitter: () => "https://x.com/seer_pm",
-  telegram: () => "https://t.me/+sFMfslAZNTA1YmQ1",
+  telegram: () => "https://t.me/seer_pm",
   verificationCheck: (id: Address | string, chainId: number) => `/verification-check/${chainId}/${id.toString()}/`,
 };


### PR DESCRIPTION
I edited the channel link on Telegram. But both the old link (t.me/+sFMfslAZNTA1YmQ1) and the new link (t.me/seer_pm) work.