### PR TITLE
Feat/UI improve

### DIFF
--- a/web/src/components/Layout/Header.tsx
+++ b/web/src/components/Layout/Header.tsx
@@ -59,7 +59,7 @@ export default function Header() {
 
         {mobileMenuOpen && <MobileMenu />}
 
-        <ul className="hidden lg:menu-horizontal gap-2 text-[16px] font-semibold space-x-[32px] justify-center w-1/3">
+        <ul className="hidden lg:menu-horizontal gap-2 text-[16px] font-semibold space-x-[32px] justify-center w-3/3">
           <li>
             <Link to={"/"} className="hover:opacity-85">
               Markets

--- a/web/src/components/Layout/Header.tsx
+++ b/web/src/components/Layout/Header.tsx
@@ -59,7 +59,7 @@ export default function Header() {
 
         {mobileMenuOpen && <MobileMenu />}
 
-        <ul className="hidden lg:menu-horizontal gap-2 text-[16px] font-semibold space-x-[32px] justify-center w-3/3">
+        <ul className="hidden lg:menu-horizontal gap-2 text-[16px] font-semibold space-x-[32px] justify-center">
           <li>
             <Link to={"/"} className="hover:opacity-85">
               Markets

--- a/web/src/pages/markets/@chainId/@id/+Page.tsx
+++ b/web/src/pages/markets/@chainId/@id/+Page.tsx
@@ -223,16 +223,14 @@ function MarketPage() {
           </Alert>
         )}
         {market && <MarketChart market={market} />}
-        <div className="grid grid-cols-1 lg:grid-cols-12 gap-10">
-          <div className="col-span-1 lg:col-span-8 space-y-16">
+        <div className=" grid grid-cols-1 lg:grid-cols-12 gap-10 ">
+          <div className="col-span-1 lg:col-span-8  h-fit space-y-16">
             {market && (
-              <>
-                <Outcomes market={market} images={images?.outcomes} />
-                <MarketTabs market={market} />
-              </>
+              <Outcomes market={market} images={images?.outcomes} />
             )}
           </div>
           <div className="col-span-1 lg:col-span-4 space-y-5">
+            
             {/* <PoolDetails market={market} outcomeIndex={outcomeIndex} /> */}
             <SwapWidget
               router={router}
@@ -243,6 +241,9 @@ function MarketPage() {
             />
 
             <ConditionalTokenActions router={router} market={market} account={account} />
+          </div>
+          <div className=" col-span-1 lg:col-span-8 space-y-16">
+            <MarketTabs market={market} />
           </div>
         </div>
       </div>

--- a/web/src/pages/markets/@chainId/@id/+Page.tsx
+++ b/web/src/pages/markets/@chainId/@id/+Page.tsx
@@ -223,11 +223,9 @@ function MarketPage() {
           </Alert>
         )}
         {market && <MarketChart market={market} />}
-        <div className=" grid grid-cols-1 lg:grid-cols-12 gap-10 ">
-          <div className="col-span-1 lg:col-span-8  h-fit space-y-16">
-            {market && (
-              <Outcomes market={market} images={images?.outcomes} />
-            )}
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-10">
+          <div className="col-span-1 lg:col-span-8 h-fit space-y-16">
+            {market && <Outcomes market={market} images={images?.outcomes} />}
           </div>
           <div className="col-span-1 lg:col-span-4 space-y-5">
             
@@ -242,7 +240,7 @@ function MarketPage() {
 
             <ConditionalTokenActions router={router} market={market} account={account} />
           </div>
-          <div className=" col-span-1 lg:col-span-8 space-y-16">
+          <div className="col-span-1 lg:col-span-8 space-y-16">
             <MarketTabs market={market} />
           </div>
         </div>


### PR DESCRIPTION
fix: Sometimes the Portfolio li can't be clicked when trying to go to "Portfolio" without first clicking the "Airdrop" li, because the ul width is too small.)
![chrome_TjwwVJfJgV](https://github.com/user-attachments/assets/d358321e-88a9-4646-9a7e-6dc95c28b6bc)

fix: On md and sm screens, the SwapWidget and Mint divs should be placed under the Outcomes div, but the Related Conditional Markets div is currently displayed there.

![Screenshot 2024-11-19 224954](https://github.com/user-attachments/assets/bb1a7f6c-bca9-42c8-9f37-7c75cbc19892)

