### PR TITLE
fix: getting update favorite data by refetching

### DIFF
--- a/web/src/hooks/useFavorites.ts
+++ b/web/src/hooks/useFavorites.ts
@@ -11,5 +11,6 @@ export const useFavorites = () => {
     queryFn: async () => {
       return fetchAuth(accessToken, "/.netlify/functions/collections", "GET");
     },
+    refetchInterval: 1000, // Refetch every 1 seconds
   });
 };


### PR DESCRIPTION
![Screenshot 2025-01-21 204019](https://github.com/user-attachments/assets/70538598-0ae4-42f7-b216-93e956e32cb0)

I noticed an issue where the favorite data does not update correctly when clicking on the favorite icon. For example, if I click the second icon, the favorite state updates for the first icon that I clicked previously.
I added automatic refetching to the useFavorites hook to ensure the favorite data array stays updated. This approach works for displaying the updated favorite data, but I'm not sure if it might introduce other issues.  Thank you :)