### PR TITLE
improve Date Table UI

### DIFF
--- a/web/src/components/Market/Outcomes.tsx
+++ b/web/src/components/Market/Outcomes.tsx
@@ -517,7 +517,7 @@ export function Outcomes({ market, images }: PositionsProps) {
               key={market.wrappedTokens[i]}
               onClick={outcomeClick(i)}
               className={clsx(
-                "bg-white flex justify-between p-[24px] border rounded-[3px] drop-shadow-sm cursor-pointer",
+                "bg-white flex justify-between p-[24px] border rounded-[3px] shadow-sm cursor-pointer",
                 activeOutcome === i ? "border-purple-primary" : "border-black-medium",
               )}
             >

--- a/web/src/components/Portfolio/DateRangePicker.tsx
+++ b/web/src/components/Portfolio/DateRangePicker.tsx
@@ -77,7 +77,7 @@ function DateRangePicker({
           {defaultRanges.map((range) => {
             return (
               <div
-                key="range"
+                key={range}
                 className={clsx(
                   "text-[14px] whitespace-nowrap cursor-pointer flex px-2 py-2 border-l-[3px] border-transparent hover:bg-purple-medium hover:border-l-purple-primary",
                   getDefaultRangeFromDates() === range &&


### PR DESCRIPTION
using drop-shadow-sm is causing the date table to be covered.
 I think defining key="range" as the default sometimes causes confusion and displaying elements like this.
![Screenshot 2025-03-31 162721](https://github.com/user-attachments/assets/a8025156-3d73-4014-b2f2-02d92dd69e40)
![Screenshot 2025-03-31 132013](https://github.com/user-attachments/assets/ca60d62d-21c1-40de-9672-35a98537765c)

