### PR TITLE
improve:  prevent covering too much on small screens

### DIFF
--- a/web/src/pages/index/+Page.tsx
+++ b/web/src/pages/index/+Page.tsx
@@ -19,7 +19,7 @@ function PageContent({ params }: { params: UseMarketsProps }) {
   return (
     <div>
       <div
-        className="px-[64px] py-[16px] sticky top-0 z-[10]"
+        className="px-[64px] py-[16px] sticky lg:top-0 z-[10]"
         style={{ background: "linear-gradient(90deg, #FFFFFF 0%, #F9F7FE 100%)" }}
       >
         <MarketsFilter />


### PR DESCRIPTION
let's edit to lg:top-0 currently, since the higher layout is covering on smaller screens.