### PR TITLE
 fix: sorting Redeem,

### DIFF
--- a/web/src/components/Portfolio/PositionsTable.tsx
+++ b/web/src/components/Portfolio/PositionsTable.tsx
@@ -194,6 +194,16 @@ export default function PositionsTable({ data, chainId }: { data: PortfolioPosit
           return <p className="text-[14px] text-black-secondary">Not yet</p>;
         },
         header: "Redeem",
+        sortingFn: (rowA, rowB) => {
+          const statusA = rowA.original.marketStatus;
+          const statusB = rowB.original.marketStatus;
+          if (statusA === MarketStatus.CLOSED && statusB !== MarketStatus.CLOSED) {
+            return -1;
+          } else if (statusA !== MarketStatus.CLOSED && statusB === MarketStatus.CLOSED) {
+            return 1;
+          }
+          return 0;
+        },
       },
     ],
     [],
@@ -233,6 +243,7 @@ export default function PositionsTable({ data, chainId }: { data: PortfolioPosit
                 type="button"
                 className="absolute right-[20px] top-[20px] hover:opacity-60"
                 onClick={() => closeModal()}
+                aria-label="Close modal"
               >
                 <CloseIcon fill="black" />
               </button>


### PR DESCRIPTION
close #295
"answer_not_final" markets are showing first, and "closed or redeemable"  markets are showing after that.
I think this is because it's sorting alphabetically — "answer_not_final" comes before "closed".

```
export enum MarketStatus {
  NOT_OPEN = "not_open",
  OPEN = "open",
  ANSWER_NOT_FINAL = "answer_not_final",
  IN_DISPUTE = "in_dispute",
  PENDING_EXECUTION = "pending_execution",
  CLOSED = "closed",
}
```

So I added some sorting code to make sure all closed markets show first when clicking "Redeem" sorting.


![Screenshot 2025-05-05 191714](https://github.com/user-attachments/assets/4d852dc2-2445-4975-8503-824125c187e4)





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the positions table with custom sorting in the "Redeem" column, prioritizing closed markets.
- **Accessibility**
	- Improved accessibility by adding a descriptive label to the modal close button for screen readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->