### PR TITLE
fix: to show all outcomes on Answer form

### DIFF
--- a/web/src/components/Market/AnswerForm.tsx
+++ b/web/src/components/Market/AnswerForm.tsx
@@ -78,11 +78,6 @@ function getOutcomesOptions(market: Market, question: Question) {
     // first map and then filter to keep the index of each outcome as value
     .map((outcome, i) => ({ value: i, text: outcome }));
 
-  if (market.type === "Generic") {
-    // the last element is the Invalid Result outcome
-    options.pop();
-  }
-
   if (Number(market.templateId) === REALITY_TEMPLATE_SINGLE_SELECT) {
     options = options.filter((_, i) => question.finalize_ts === 0 || i !== hexToNumber(question.best_answer));
   }


### PR DESCRIPTION
I think this code is an issue - it removes the last valid outcome #379


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the “Invalid Result” option in Generic markets within the answer form. Users can now see and select this outcome when submitting answers, ensuring all expected options are available. Existing SINGLE_SELECT behavior remains unchanged, improving consistency and clarity for users participating in Generic market submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->