### PR TITLE
fix: price after buy amount no longer 1

### DIFF
--- a/web/src/components/Market/SwapTokens/SwapTokensMarket.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensMarket.tsx
@@ -537,7 +537,7 @@ export function SwapTokensMarket({
 
           {!!limitPriceFromVolume && (
             <div className="flex justify-between text-[#828282] text-[14px]">
-              Price after buy
+              Price after {swapType}
               {quoteIsLoading || isFetching ? (
                 <div className="shimmer-container ml-2 w-[100px]" />
               ) : (

--- a/web/src/hooks/liquidity/usePriceUntilVolume.ts
+++ b/web/src/hooks/liquidity/usePriceUntilVolume.ts
@@ -22,8 +22,6 @@ export function getPriceFromVolume(
 
   const isOutcomeToken0 = isTwoStringsEqual(pool.token0, outcome);
 
-  const movingUp = (isOutcomeToken0 && swapType === "buy") || (!isOutcomeToken0 && swapType === "sell");
-
   const currentPrice = Number(tickToPrice(pool.tick, 18, true)[isOutcomeToken0 ? 0 : 1]);
 
   // Search bounds
@@ -37,7 +35,7 @@ export function getPriceFromVolume(
 
     if (Math.abs(vol - targetVolume) <= tolerance) break;
 
-    if (movingUp) {
+    if (swapType === "buy") {
       if (vol < targetVolume) low = mid;
       else high = mid;
     } else {


### PR DESCRIPTION
was 1 on certain tokens, maybe due
to an token0 ordering bug,
also swapped label when Price after sell

Before:


<img width="349" height="539" alt="image" src="https://github.com/user-attachments/assets/7acc8882-cf53-4231-960e-7609fd63ee43" />


After: 

<img width="321" height="450" alt="image" src="https://github.com/user-attachments/assets/0371cebf-31ec-44cc-a4aa-2a25f3bf6ac4" />

<img width="334" height="523" alt="image" src="https://github.com/user-attachments/assets/3efd3aa6-75bd-4f72-9077-460da38b98f1" />
