### PR TITLE
fix bottom sheet links

### DIFF
--- a/web/src/components/Market/Outcomes.tsx
+++ b/web/src/components/Market/Outcomes.tsx
@@ -34,7 +34,7 @@ interface OutcomesProps {
   market: Market;
   images?: string[];
   activeOutcome: number;
-  onOutcomeChange: (i: number, isClick: boolean) => void;
+  onOutcomeChange: (i: number, openDrawer: boolean) => void;
 }
 
 function poolRewardsInfo(pool: PoolInfo) {
@@ -539,6 +539,7 @@ export function Outcomes({ market, images, activeOutcome, onOutcomeChange }: Out
                   type="radio"
                   name="outcome"
                   className="radio max-lg:hidden"
+                  readOnly
                   checked={activeOutcome === i || (market.type === "Futarchy" && activeOutcome === i + 2)}
                 />
               </div>

--- a/web/src/pages/markets/@chainId/@id/+Page.tsx
+++ b/web/src/pages/markets/@chainId/@id/+Page.tsx
@@ -38,7 +38,7 @@ function SwapWidget({
   market: Market;
   outcomeIndex: number;
   images?: string[];
-  onOutcomeChange: (i: number, isClick: boolean) => void;
+  onOutcomeChange: (i: number, openDrawer: boolean) => void;
 }) {
   // Preload all outcome tokens to populate cache and avoid flicker while loading
   useTokensInfo(market.wrappedTokens, market.chainId);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interaction for market outcome rows: links and buttons no longer block row clicks, so controls act normally and row clicks toggle selection only when appropriate.
  * Drawer behavior refined on mobile: the details drawer now opens only when outcome interactions explicitly request it, matching expected tap behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->