### PR TITLE
add outcomes dropdown, closes #471

### DIFF
--- a/web/src/components/Dropdown.tsx
+++ b/web/src/components/Dropdown.tsx
@@ -20,7 +20,7 @@ export function Dropdown({ options, value, onClick, defaultLabel }: DropdownProp
       setIsOpen={setIsOpen}
       className="w-[200px]"
       content={
-        <div className="p-2">
+        <ul className="p-2">
           {options.map((option) => (
             <li
               key={option.value.toString()}
@@ -38,7 +38,7 @@ export function Dropdown({ options, value, onClick, defaultLabel }: DropdownProp
               <span>{option.text}</span>
             </li>
           ))}
-        </div>
+        </ul>
       }
     >
       <div className="text-[14px] font-semibold cursor-pointer flex items-center whitespace-nowrap">

--- a/web/src/components/Market/CollateralDropdown.tsx
+++ b/web/src/components/Market/CollateralDropdown.tsx
@@ -97,7 +97,7 @@ export function CollateralDropdown(props: CollateralDropdownProps) {
                   />
                 )}
               </div>
-              <p className="font-semibold text-[16px]">{collateralToken.symbol}</p>
+              <p className="font-semibold text-[16px] whitespace-nowrap">{collateralToken.symbol}</p>
             </li>
           ))}
         </div>
@@ -118,7 +118,7 @@ export function CollateralDropdown(props: CollateralDropdownProps) {
             />
           )}
         </div>
-        <p className="font-semibold text-[16px]">{selectedCollateral.symbol}</p>
+        <p className="font-semibold text-[16px] whitespace-nowrap">{selectedCollateral.symbol}</p>
         <ArrowDropDown />
       </div>
     </DropdownWrapper>

--- a/web/src/components/Market/CollateralDropdown.tsx
+++ b/web/src/components/Market/CollateralDropdown.tsx
@@ -69,7 +69,7 @@ export function CollateralDropdown(props: CollateralDropdownProps) {
       isOpen={isOpen}
       setIsOpen={setIsOpen}
       content={
-        <div className="p-2">
+        <ul className="p-2">
           {collateralTokens.map((collateralToken) => (
             <li
               key={collateralToken.address}
@@ -100,7 +100,7 @@ export function CollateralDropdown(props: CollateralDropdownProps) {
               <p className="font-semibold text-[16px] whitespace-nowrap">{collateralToken.symbol}</p>
             </li>
           ))}
-        </div>
+        </ul>
       }
     >
       <div className="flex items-center gap-1 rounded-full border border-[#f2f2f2] dark:border-neutral px-3 py-1 shadow-[0_0_10px_rgba(34,34,34,0.04)] hover:bg-base-300/60 dark:hover:bg-base-200 cursor-pointer">

--- a/web/src/components/Market/OutcomeDropdown.tsx
+++ b/web/src/components/Market/OutcomeDropdown.tsx
@@ -50,7 +50,7 @@ export function OutcomeDropdown({ market, outcomeIndex, onOutcomeChange }: Outco
       setIsOpen={setIsOpen}
       direction="auto"
       content={
-        <div className="p-2">
+        <ul className="p-2">
           {outcomeTokens.map((token, index) => (
             <li
               key={token.address}
@@ -75,7 +75,7 @@ export function OutcomeDropdown({ market, outcomeIndex, onOutcomeChange }: Outco
               <p className="font-semibold text-[16px] whitespace-nowrap">{token.symbol}</p>
             </li>
           ))}
-        </div>
+        </ul>
       }
     >
       <div className="flex items-center gap-1 rounded-full border border-[#f2f2f2] dark:border-neutral px-3 py-1 shadow-[0_0_10px_rgba(34,34,34,0.04)] hover:bg-base-300/60 dark:hover:bg-base-200 cursor-pointer">

--- a/web/src/components/Market/OutcomeDropdown.tsx
+++ b/web/src/components/Market/OutcomeDropdown.tsx
@@ -1,0 +1,95 @@
+import { ArrowDropDown } from "@/lib/icons";
+import { useTokensInfo } from "@seer-pm/react";
+import { Market } from "@seer-pm/sdk";
+import clsx from "clsx";
+import { useState } from "react";
+import DropdownWrapper from "../Form/DropdownWrapper";
+import { OutcomeImage } from "./OutcomeImage";
+
+type OutcomeDropdownProps = {
+  market: Market;
+  outcomeIndex: number;
+  onOutcomeChange: (i: number, isClick: boolean) => void;
+};
+
+function isInvalidOutcomeIndex(market: Market, index: number) {
+  return market.type === "Generic" && index === market.wrappedTokens.length - 1;
+}
+
+export function OutcomeDropdown({ market, outcomeIndex, onOutcomeChange }: OutcomeDropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const { data: outcomeTokens } = useTokensInfo(market.wrappedTokens, market.chainId);
+
+  if (!outcomeTokens || outcomeTokens.length === 0) {
+    return null;
+  }
+
+  const selectedToken = outcomeTokens[outcomeIndex];
+  const selectedImage = market.images?.outcomes?.[outcomeIndex];
+  const selectedIsInvalid = isInvalidOutcomeIndex(market, outcomeIndex);
+
+  if (market.outcomes.length <= 1) {
+    return (
+      <div className="flex items-center gap-1 rounded-full border border-[#f2f2f2] dark:border-neutral px-3 py-1 shadow-[0_0_10px_rgba(34,34,34,0.04)]">
+        <div className="rounded-full w-6 h-6 overflow-hidden flex-shrink-0">
+          <OutcomeImage
+            className="w-full h-full"
+            image={selectedImage}
+            isInvalidOutcome={selectedIsInvalid}
+            title={market.outcomes[outcomeIndex]}
+          />
+        </div>
+        <p className="font-semibold text-[16px] whitespace-nowrap">{selectedToken.symbol}</p>
+      </div>
+    );
+  }
+
+  return (
+    <DropdownWrapper
+      isOpen={isOpen}
+      setIsOpen={setIsOpen}
+      direction="auto"
+      content={
+        <div className="p-2">
+          {outcomeTokens.map((token, index) => (
+            <li
+              key={token.address}
+              onClick={() => {
+                onOutcomeChange(index, false);
+                setIsOpen(false);
+              }}
+              className={clsx(
+                "px-[15px] py-[10px] border-l-[3px] border-transparent hover:bg-purple-medium dark:hover:bg-neutral hover:border-l-purple-primary flex items-center gap-2 cursor-pointer",
+                index === outcomeIndex &&
+                  "active border-l-[3px] border-l-purple-primary bg-purple-medium dark:bg-neutral",
+              )}
+            >
+              <div className="w-6 h-6 overflow-hidden flex-shrink-0">
+                <OutcomeImage
+                  className="w-full h-full"
+                  image={market.images?.outcomes?.[index]}
+                  isInvalidOutcome={isInvalidOutcomeIndex(market, index)}
+                  title={market.outcomes[index]}
+                />
+              </div>
+              <p className="font-semibold text-[16px] whitespace-nowrap">{token.symbol}</p>
+            </li>
+          ))}
+        </div>
+      }
+    >
+      <div className="flex items-center gap-1 rounded-full border border-[#f2f2f2] dark:border-neutral px-3 py-1 shadow-[0_0_10px_rgba(34,34,34,0.04)] hover:bg-base-300/60 dark:hover:bg-base-200 cursor-pointer">
+        <div className="rounded-full w-6 h-6 overflow-hidden flex-shrink-0">
+          <OutcomeImage
+            className="w-full h-full"
+            image={selectedImage}
+            isInvalidOutcome={selectedIsInvalid}
+            title={market.outcomes[outcomeIndex]}
+          />
+        </div>
+        <p className="font-semibold text-[16px] whitespace-nowrap">{selectedToken.symbol}</p>
+        <ArrowDropDown />
+      </div>
+    </DropdownWrapper>
+  );
+}

--- a/web/src/components/Market/SwapTokens/SwapTokens.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokens.tsx
@@ -2,7 +2,6 @@ import { Dropdown } from "@/components/Dropdown";
 import { getLiquidityUrlByMarket, isFillToEstimateEnabled } from "@seer-pm/sdk";
 import { Market } from "@seer-pm/sdk";
 import type { Token } from "@seer-pm/sdk";
-import clsx from "clsx";
 import { useState } from "react";
 import { Alert } from "../../Alert";
 import { OutcomeImage } from "../OutcomeImage";
@@ -67,12 +66,7 @@ export function SwapTokens({
         </Alert>
       )}
       {!isShowMaxSlippage && (
-        <div
-          className={clsx(
-            "space-y-5",
-            hasEnoughLiquidity === false && orderType === "market" && "grayscale opacity-40 pointer-events-none",
-          )}
-        >
+        <div className="space-y-5">
           {/* Futarchy markets only support Market orders */}
           {market.type === "Generic" && (
             <div className="flex items-center justify-between">
@@ -105,6 +99,7 @@ export function SwapTokens({
               setShowMaxSlippage={setShowMaxSlippage}
               outcomeImage={outcomeImage}
               isInvalidOutcome={isInvalidOutcome}
+              onOutcomeChange={onOutcomeChange}
             />
           )}
           {orderType === "fill-to-estimate" && (

--- a/web/src/components/Market/SwapTokens/SwapTokensLimitUpTo.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensLimitUpTo.tsx
@@ -45,6 +45,7 @@ interface SwapTokensLimitUptoProps {
   setShowMaxSlippage: (isShow: boolean) => void;
   outcomeImage?: string;
   isInvalidOutcome: boolean;
+  onOutcomeChange: (i: number, isClick: boolean) => void;
 }
 
 export function SwapTokensLimitUpto({
@@ -55,6 +56,7 @@ export function SwapTokensLimitUpto({
   fixedCollateral,
   outcomeImage,
   isInvalidOutcome,
+  onOutcomeChange,
 }: SwapTokensLimitUptoProps) {
   const limitPriceRef = useRef<HTMLInputElement | null>(null);
   const [swapType, setSwapType] = useState<"buy" | "sell">("buy");
@@ -418,7 +420,7 @@ export function SwapTokensLimitUpto({
                     src={paths.tokenImage(primaryCollateral.address, market.chainId)}
                   />
                 </div>
-                <p className="font-semibold text-[16px]">{primaryCollateral.symbol}</p>
+                <p className="font-semibold text-[16px] whitespace-nowrap">{primaryCollateral.symbol}</p>
               </div>
             </div>
           </div>
@@ -472,6 +474,7 @@ export function SwapTokensLimitUpto({
                   outcomeImage,
                   isInvalidOutcome,
                   outcomeText,
+                  onOutcomeChange,
                 }}
               />
             </div>
@@ -532,6 +535,7 @@ export function SwapTokensLimitUpto({
                   outcomeImage,
                   isInvalidOutcome,
                   outcomeText,
+                  onOutcomeChange,
                 }}
               />
             </div>

--- a/web/src/components/Market/SwapTokens/SwapTokensMarket.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensMarket.tsx
@@ -433,6 +433,7 @@ export function SwapTokensMarket({
                   outcomeImage,
                   isInvalidOutcome,
                   outcomeText,
+                  onOutcomeChange,
                 }}
               />
             </div>
@@ -531,6 +532,7 @@ export function SwapTokensMarket({
                   outcomeImage,
                   isInvalidOutcome,
                   outcomeText,
+                  onOutcomeChange,
                 }}
               />
             </div>

--- a/web/src/components/Market/SwapTokens/TokenSelector.tsx
+++ b/web/src/components/Market/SwapTokens/TokenSelector.tsx
@@ -41,7 +41,7 @@ export const TokenSelector = ({
     type === "sell" ? sellToken.address : buyToken.address,
     selectedCollateral.address,
   );
-  if (!isTokenCollateral && onOutcomeChange) {
+  if (!isTokenCollateral && onOutcomeChange && market.type !== "Futarchy") {
     return <OutcomeDropdown market={market} outcomeIndex={outcomeIndex} onOutcomeChange={onOutcomeChange} />;
   }
   if (isTokenCollateral && isUndefined(fixedCollateral)) {

--- a/web/src/components/Market/SwapTokens/TokenSelector.tsx
+++ b/web/src/components/Market/SwapTokens/TokenSelector.tsx
@@ -3,6 +3,7 @@ import { isTwoStringsEqual, isUndefined } from "@/lib/utils";
 import { FUTARCHY_LP_PAIRS_MAPPING, Market } from "@seer-pm/sdk";
 import type { Token } from "@seer-pm/sdk";
 import { MarketCollateralDropdown } from "../CollateralDropdown";
+import { OutcomeDropdown } from "../OutcomeDropdown";
 import { OutcomeImage } from "../OutcomeImage";
 
 interface TokenSelectorProps {
@@ -18,6 +19,7 @@ interface TokenSelectorProps {
   outcomeImage?: string;
   isInvalidOutcome: boolean;
   outcomeText: string;
+  onOutcomeChange?: (i: number, isClick: boolean) => void;
 }
 
 export const TokenSelector = ({
@@ -33,11 +35,15 @@ export const TokenSelector = ({
   outcomeImage,
   isInvalidOutcome,
   outcomeText,
+  onOutcomeChange,
 }: TokenSelectorProps) => {
   const isTokenCollateral = isTwoStringsEqual(
     type === "sell" ? sellToken.address : buyToken.address,
     selectedCollateral.address,
   );
+  if (!isTokenCollateral && onOutcomeChange) {
+    return <OutcomeDropdown market={market} outcomeIndex={outcomeIndex} onOutcomeChange={onOutcomeChange} />;
+  }
   if (isTokenCollateral && isUndefined(fixedCollateral)) {
     return (
       <MarketCollateralDropdown
@@ -116,7 +122,7 @@ export function TokenImage({ token }: { token: Token }) {
       <div className="rounded-full w-6 h-6 overflow-hidden flex-shrink-0">
         <img className="w-full h-full" alt={token.symbol} src={paths.tokenImage(token.address, token.chainId)} />
       </div>
-      <p className="font-semibold text-[16px]">{token.symbol}</p>
+      <p className="font-semibold text-[16px] whitespace-nowrap">{token.symbol}</p>
     </div>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an outcome selector for markets, allowing users to switch between available outcomes directly in token selection areas.
  * Outcome selections now appear in both sell and buy flows where applicable.

* **Bug Fixes**
  * Improved token and outcome label display so symbols stay on one line and no longer wrap awkwardly.
  * Refined the market swap interface so outcome selection works consistently across related trading screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->