### PR TITLE
Display commenter's positions 

### DIFF
--- a/packages/seer-pm-discussions/README.md
+++ b/packages/seer-pm-discussions/README.md
@@ -9,6 +9,7 @@ import {
   Discussion,
   createDiscussionsClient,
   userFromAddress,
+  type DiscussionUserPositionBadgeProps,
   type DiscussionButtonProps,
 } from "@seer-pm/discussions";
 
@@ -33,15 +34,21 @@ function DiscussionButton({
   );
 }
 
+function UserPositionBadge({ user }: DiscussionUserPositionBadgeProps) {
+  return <YourBadge address={user.address} />;
+}
+
 <Discussion
   client={client}
   user={address ? userFromAddress(address) : null}
   onRequestConnect={signIn}
-  components={{ Button: DiscussionButton }}
+  components={{ Button: DiscussionButton, UserPositionBadge }}
 />
 ```
 
 Pass your design-system button via `components.Button`. If omitted, CTAs fall back to a plain HTML `<button>` with no package styles. You can also pass `components.ConnectButton` to fully replace the signed-out connect CTA.
+
+Use `components.UserPositionBadge` to render the commenter's position in the current market beside their name.
 
 Author labels resolve primary ENS names via wagmi (`useEnsName`, mainnet). Wrap the tree in a `WagmiProvider` whose config includes mainnet so reverse lookups succeed; without that, addresses fall back to a shortened form.
 
@@ -87,10 +94,10 @@ You can also pass `className` / `style` on `<Discussion />` (including CSS varia
 
 ## Public API
 
-- `Discussion` — thread UI (`components.Button` / `components.ConnectButton`)
+- `Discussion` — thread UI (`components.Button` / `components.ConnectButton` / `components.UserPositionBadge`)
 - `createDiscussionsClient` — HTTP client (`marketId`, `listComments`, `createComment`, `editComment`, `deleteComment`, `setLike`)
 - `useDiscussions` — context hook
 - `userFromAddress` — build `DiscussionUser` from a wallet
 - `SD_ROOT_CLASS` — root class name for theming (`"sd-root"`)
 - `@seer-pm/discussions/tailwind` — Tailwind preset (`sd-*` colors)
-- Types: `DiscussionButtonProps`, `DiscussionConnectButtonProps`, `DiscussionComponents`
+- Types: `DiscussionButtonProps`, `DiscussionConnectButtonProps`, `DiscussionUserPositionBadgeProps`, `DiscussionComponents`

--- a/packages/seer-pm-discussions/package.json
+++ b/packages/seer-pm-discussions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seer-pm/discussions",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Market discussion UI for Seer",
   "license": "MIT",
   "author": "Seer",

--- a/packages/seer-pm-discussions/src/components/DiscussionsProvider/DiscussionsProvider.tsx
+++ b/packages/seer-pm-discussions/src/components/DiscussionsProvider/DiscussionsProvider.tsx
@@ -29,8 +29,9 @@ export default function DiscussionsProvider({
     () => ({
       Button: componentsProp?.Button ?? DefaultButton,
       ConnectButton: componentsProp?.ConnectButton,
+      UserPositionBadge: componentsProp?.UserPositionBadge,
     }),
-    [componentsProp?.Button, componentsProp?.ConnectButton],
+    [componentsProp?.Button, componentsProp?.ConnectButton, componentsProp?.UserPositionBadge],
   );
 
   return (

--- a/packages/seer-pm-discussions/src/components/Post/Post.tsx
+++ b/packages/seer-pm-discussions/src/components/Post/Post.tsx
@@ -25,6 +25,7 @@ const UNDO_MS = 5000;
 export default function Post({ post, showPfp = true, showCta = true, characterLimit = null }: PostProps) {
   const { user, client, onRequestConnect, components } = useDiscussions();
   const Button = components.Button;
+  const UserPositionBadge = components.UserPositionBadge;
   const [editPost, setEditPost] = useState(false);
   const [isDeleted, setIsDeleted] = useState(false);
   const [pendingDelete, setPendingDelete] = useState(false);
@@ -147,10 +148,11 @@ export default function Post({ post, showPfp = true, showCta = true, characterLi
         <div className="ml-3 min-w-0 flex-1 flex-col">
           {showPfp && (
             <div className="flex flex-row items-center">
-              <div className="flex min-w-0 flex-1 flex-row items-center">
+              <div className="flex min-w-0 flex-1 flex-row items-center gap-2">
                 <span className="truncate text-[15px] font-medium text-sd-color-main">
                   <Username details={post.authorDetails} />
                 </span>
+                {UserPositionBadge && <UserPositionBadge user={post.authorDetails} />}
               </div>
               <div className="sd-timestamp-mobile mr-2 flex shrink-0 items-center justify-self-end text-[12px] font-normal text-sd-color-secondary">
                 <TimeAgo style={{ display: "flex", fontSize: 12 }} date={post.createdAt * 1000} locale="en-US" />

--- a/packages/seer-pm-discussions/src/index.ts
+++ b/packages/seer-pm-discussions/src/index.ts
@@ -14,6 +14,7 @@ export type {
   CreateCommentInput,
   DiscussionButtonProps,
   DiscussionConnectButtonProps,
+  DiscussionUserPositionBadgeProps,
   DiscussionComponents,
 } from "./types";
 

--- a/packages/seer-pm-discussions/src/types.ts
+++ b/packages/seer-pm-discussions/src/types.ts
@@ -19,14 +19,20 @@ export type DiscussionConnectButtonProps = {
   isLoading?: boolean;
 };
 
+export type DiscussionUserPositionBadgeProps = {
+  user: DiscussionUser;
+};
+
 export type DiscussionComponents = {
   Button?: ComponentType<DiscussionButtonProps>;
   ConnectButton?: ComponentType<DiscussionConnectButtonProps>;
+  UserPositionBadge?: ComponentType<DiscussionUserPositionBadgeProps>;
 };
 
 export type ResolvedDiscussionComponents = {
   Button: ComponentType<DiscussionButtonProps>;
   ConnectButton?: ComponentType<DiscussionConnectButtonProps>;
+  UserPositionBadge?: ComponentType<DiscussionUserPositionBadgeProps>;
 };
 
 export type Comment = {

--- a/web/src/components/Market/MarketTabs/Comments.tsx
+++ b/web/src/components/Market/MarketTabs/Comments.tsx
@@ -53,11 +53,13 @@ function DiscussionButton({
   );
 }
 
+/** Displays one outcome position or a tooltip summarizing multiple positions. */
 function PositionBadge({ positions }: { positions: OutcomePosition[] }) {
   if (positions.length === 0) return null;
 
   const pillClassName =
     "max-w-40 shrink truncate rounded-full border border-sd-color-active bg-sd-color-active px-2 py-0.5 text-[11px] font-medium leading-4 text-white";
+  /** Formats a position for tooltip and accessibility labels. */
   const formatPositionLabel = ({ outcome, balance }: OutcomePosition) =>
     `${outcome}: ${displayBalance(balance, 18, true)} shares`;
 
@@ -143,13 +145,13 @@ function Comments({ market }: { market: Market }) {
     return positionsByAddress;
   }, [marketHolders?.topHolders, market.outcomes, market.wrappedTokens]);
 
-  const UserPositionBadge = useMemo(
-    () =>
-      function UserPositionBadge({ user }: DiscussionUserPositionBadgeProps) {
-        return <PositionBadge positions={positionsByUserAddress.get(user.address.toLowerCase()) ?? []} />;
-      },
-    [positionsByUserAddress],
-  );
+  const UserPositionBadge = useMemo(() => {
+    /** Displays the current market positions held by a discussion user. */
+    function UserPositionBadge({ user }: DiscussionUserPositionBadgeProps) {
+      return <PositionBadge positions={positionsByUserAddress.get(user.address.toLowerCase()) ?? []} />;
+    }
+    return UserPositionBadge;
+  }, [positionsByUserAddress]);
 
   const discussionComponents = useMemo(() => ({ Button: DiscussionButton, UserPositionBadge }), [UserPositionBadge]);
 

--- a/web/src/components/Market/MarketTabs/Comments.tsx
+++ b/web/src/components/Market/MarketTabs/Comments.tsx
@@ -57,7 +57,7 @@ function PositionBadge({ positions }: { positions: OutcomePosition[] }) {
   if (positions.length === 0) return null;
 
   const pillClassName =
-    "max-w-40 shrink truncate rounded-full border border-sd-border-main bg-sd-bg-secondary px-2 py-0.5 text-[11px] font-medium leading-4 text-sd-color-secondary";
+    "max-w-40 shrink truncate rounded-full border border-sd-color-active bg-sd-color-active px-2 py-0.5 text-[11px] font-medium leading-4 text-white";
   const formatPositionLabel = ({ outcome, balance }: OutcomePosition) =>
     `${outcome}: ${displayBalance(balance, 18, true)} shares`;
 

--- a/web/src/components/Market/MarketTabs/Comments.tsx
+++ b/web/src/components/Market/MarketTabs/Comments.tsx
@@ -1,14 +1,28 @@
 import ErrorBoundary from "@/components/ErrorBoundary";
 import Button from "@/components/Form/Button";
+import Tooltip from "@/components/Tooltip";
 import { useGlobalState } from "@/hooks/useGlobalState";
 import { useIsAccountConnected, useIsConnectedAndSignedIn } from "@/hooks/useIsConnectedAndSignedIn";
+import { useMarketHolders } from "@/hooks/useMarketHolders";
 import { useSignIn } from "@/hooks/useSignIn";
-import { getAppUrl, isAccessTokenExpired } from "@/lib/utils";
-import { Discussion, type DiscussionButtonProps, createDiscussionsClient, userFromAddress } from "@seer-pm/discussions";
-import { Market } from "@seer-pm/sdk";
+import { displayBalance, getAppUrl, isAccessTokenExpired, isTwoStringsEqual } from "@/lib/utils";
+import {
+  Discussion,
+  type DiscussionButtonProps,
+  type DiscussionUserPositionBadgeProps,
+  createDiscussionsClient,
+  userFromAddress,
+} from "@seer-pm/discussions";
+import type { Market } from "@seer-pm/sdk";
 import { useWeb3Modal } from "@web3modal/wagmi/react";
 import { Children, type ReactNode, useMemo } from "react";
 import { useAccount } from "wagmi";
+
+type OutcomePosition = {
+  tokenId: string;
+  outcome: string;
+  balance: bigint;
+};
 
 function buttonLabel(children: ReactNode): string {
   const text = Children.toArray(children)
@@ -39,12 +53,58 @@ function DiscussionButton({
   );
 }
 
+function PositionBadge({ positions }: { positions: OutcomePosition[] }) {
+  if (positions.length === 0) return null;
+
+  const pillClassName =
+    "max-w-40 shrink truncate rounded-full border border-sd-border-main bg-sd-bg-secondary px-2 py-0.5 text-[11px] font-medium leading-4 text-sd-color-secondary";
+  const formatPositionLabel = ({ outcome, balance }: OutcomePosition) =>
+    `${outcome}: ${displayBalance(balance, 18, true)} shares`;
+
+  if (positions.length === 1) {
+    const [position] = positions;
+    return (
+      <span className={pillClassName} title={formatPositionLabel(position)}>
+        {position.outcome} {displayBalance(position.balance, 18, true)}
+      </span>
+    );
+  }
+
+  return (
+    <Tooltip
+      trigger={
+        <button
+          type="button"
+          className={`${pillClassName} cursor-help`}
+          aria-label={`Multiple positions: ${positions.map(formatPositionLabel).join(", ")}`}
+        >
+          Multiple Positions
+        </button>
+      }
+      content={
+        <div className="min-w-40">
+          <p className="m-0 mb-1.5 text-xs font-semibold">Positions held</p>
+          <ul className="m-0 list-none space-y-1 p-0">
+            {positions.map(({ tokenId, outcome, balance }) => (
+              <li key={tokenId} className="flex items-center justify-between gap-4 font-normal">
+                <span>{outcome}</span>
+                <span className="tabular-nums">{displayBalance(balance, 18, true)}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      }
+    />
+  );
+}
+
 function Comments({ market }: { market: Market }) {
   const { address, chainId } = useAccount();
   const isConnected = useIsAccountConnected();
   const isSignedIn = useIsConnectedAndSignedIn();
   const signIn = useSignIn();
   const { open } = useWeb3Modal();
+  const { data: marketHolders } = useMarketHolders(market);
 
   const client = useMemo(
     () =>
@@ -61,6 +121,38 @@ function Comments({ market }: { market: Market }) {
 
   const user = isSignedIn && address ? userFromAddress(address) : null;
 
+  const positionsByUserAddress = useMemo(() => {
+    const positionsByAddress = new Map<string, OutcomePosition[]>();
+
+    for (const [tokenId, holders] of Object.entries(marketHolders?.topHolders ?? {})) {
+      const outcomeIndex = market.wrappedTokens.findIndex((wrappedToken) => isTwoStringsEqual(wrappedToken, tokenId));
+      const outcome = market.outcomes[outcomeIndex];
+      if (!outcome) continue;
+
+      for (const holder of holders) {
+        const balance = BigInt(holder.balance);
+        if (balance <= 0n) continue;
+
+        const userAddress = holder.address.toLowerCase();
+        const userPositions = positionsByAddress.get(userAddress) ?? [];
+        userPositions.push({ tokenId, outcome, balance });
+        positionsByAddress.set(userAddress, userPositions);
+      }
+    }
+
+    return positionsByAddress;
+  }, [marketHolders?.topHolders, market.outcomes, market.wrappedTokens]);
+
+  const UserPositionBadge = useMemo(
+    () =>
+      function UserPositionBadge({ user }: DiscussionUserPositionBadgeProps) {
+        return <PositionBadge positions={positionsByUserAddress.get(user.address.toLowerCase()) ?? []} />;
+      },
+    [positionsByUserAddress],
+  );
+
+  const discussionComponents = useMemo(() => ({ Button: DiscussionButton, UserPositionBadge }), [UserPositionBadge]);
+
   const requestConnect = async () => {
     if (!isConnected || !address || !chainId) {
       await open({ view: "Connect" });
@@ -72,12 +164,7 @@ function Comments({ market }: { market: Market }) {
 
   return (
     <ErrorBoundary fallback={<p>Something went wrong.</p>}>
-      <Discussion
-        client={client}
-        user={user}
-        onRequestConnect={requestConnect}
-        components={{ Button: DiscussionButton }}
-      />
+      <Discussion client={client} user={user} onRequestConnect={requestConnect} components={discussionComponents} />
     </ErrorBoundary>
   );
 }

--- a/web/src/components/Tooltip.tsx
+++ b/web/src/components/Tooltip.tsx
@@ -56,7 +56,14 @@ export default function Tooltip({ trigger, content }: TooltipProps) {
 
   return (
     <>
-      <div ref={triggerRef} className="inline-block" onMouseEnter={show} onMouseLeave={hide}>
+      <div
+        ref={triggerRef}
+        className="inline-block"
+        onMouseEnter={show}
+        onMouseLeave={hide}
+        onFocus={show}
+        onBlur={hide}
+      >
         {trigger}
       </div>
 
@@ -64,6 +71,7 @@ export default function Tooltip({ trigger, content }: TooltipProps) {
         ReactDOM.createPortal(
           <div
             ref={tooltipRef}
+            role="tooltip"
             onMouseEnter={show}
             onMouseLeave={hide}
             style={{


### PR DESCRIPTION
Adding a small pill that shows the current positions held my the author of a comment in the discussion section. If the author only has one position it is displayed directly in the pill. If they have more than one the pill displays 'Multiple Positions' and hovering reveals a tooltip that shows all positions.

The latter case will likely happen quite frequently as it is common to end up with 'Invalid' holdings due to minting and selling. I thought about always hiding 'Invalid' positions, but don't want to hide it in the case where people are genuinely wanting to bet on invalid (eg Romanian election). 

Defaulting to multiple positions was the most straight forward but I am open to improvements? Maybe: If they only have invalid display it directly. If they have exactly one position as well as invalid, display the other position directly. If they have multiple non invalid positions list as 'Multiple Positions'. Always make the position hoverable so you can see all positions including invalid (eg pill says: 100 Yes. Hovering displays 100 Yes, 200 Invalid)

<img width="884" height="757" alt="image" src="https://github.com/user-attachments/assets/46e94e07-3a66-47f3-998e-0992fb1ff660" />

<img width="884" height="468" alt="image" src="https://github.com/user-attachments/assets/1e5c3c43-91f5-4f73-be31-1e55442ab4a6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Discussion comments can now display badges showing a user’s market position.
  * Users with multiple positions can view detailed position information via a tooltip.
  * Added support for customizing user position badges in discussions.

* **Accessibility**
  * Tooltips now appear when focused with a keyboard and include appropriate tooltip semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->