### PR TITLE
Show relayer-signed split/merge/redeem in the History tab

### DIFF
--- a/packages/seer-pm-sdk/queries/markets.graphql
+++ b/packages/seer-pm-sdk/queries/markets.graphql
@@ -265,3 +265,22 @@ query GetAccountActivities($account: String!) {
     transferCount
   }
 }
+
+# Every address that has touched an indexed token on one chain, paged. Unlike the per-account
+# lookup above this is a scan, so callers must page it and keep the ordering stable on `id`
+# (`chainId:account`, unique).
+query GetAccountActivitiesByChain(
+  $where: AccountActivity_bool_exp
+  $offset: Int = 0
+  $limit: Int = 1000
+  $orderBy: [AccountActivity_order_by!]
+) {
+  AccountActivity(where: $where, offset: $offset, limit: $limit, order_by: $orderBy) {
+    id
+    chainId
+    account
+    earliestTransferTimestamp
+    lastTransferTimestamp
+    transferCount
+  }
+}

--- a/packages/seer-pm-sdk/src/portfolio-types.ts
+++ b/packages/seer-pm-sdk/src/portfolio-types.ts
@@ -63,6 +63,12 @@ export type PortfolioPnLData = {
   endTime: number;
   /** Snapshot write time when the value came from `pnl_leaderboard`. */
   updatedAt?: string | null;
+  /**
+   * False when these numbers are a placeholder rather than a measurement — no materialized
+   * `pnl_leaderboard` row for the wallet set, or a compute that failed. Render "not computed",
+   * never `$0`: the two differ, and only one of them is a claim about the account.
+   */
+  computed?: boolean;
   /** Present on the global (leaderboard) path; values are USD. Market-scoped live compute omits this (native collateral). */
   unit?: "USD";
 };

--- a/web/netlify/functions/get-portfolio-pl.mts
+++ b/web/netlify/functions/get-portfolio-pl.mts
@@ -39,7 +39,8 @@ const supabase = createClient<Database>(process.env.SUPABASE_PROJECT_URL!, proce
  * - `updatedAt` is that snapshot timestamp. `period=all` keeps `startTime` null.
  * - May be stale until the next successful refresh; wallets never selected as candidates
  *   (no analytics activity in the window, or still waiting on the stale/missing rotation)
- *   stay at zeros.
+ *   stay at zeros. Those zeros carry `computed: false` — they are the absence of a measurement,
+ *   not a P/L of zero, and a consumer must not render them as `$0`.
  *
  * `debug=1` (market-scoped only): attaches a `debug` object for the requested `period`
  * (formula breakdown + swap sample rows). Ignored on the global path.
@@ -92,7 +93,12 @@ async function portfolioPlFromLeaderboard(args: {
   const { identity, chainId, period, endTime } = args;
   const accountLc = identity.account;
 
-  const zeros = (windowEnd: number, startTime: number | null, updatedAt: string | null): PortfolioPlPeriodSnapshot => ({
+  const zeros = (
+    windowEnd: number,
+    startTime: number | null,
+    updatedAt: string | null,
+    computed: boolean,
+  ): PortfolioPlPeriodSnapshot => ({
     account: accountLc,
     chainId,
     period,
@@ -107,6 +113,7 @@ async function portfolioPlFromLeaderboard(args: {
     capitalDeployed: 0,
     pnl: 0,
     updatedAt,
+    computed,
     unit: "USD",
   });
 
@@ -131,8 +138,12 @@ async function portfolioPlFromLeaderboard(args: {
 
   const rows = (data ?? []) as LeaderboardUsdRow[];
   if (rows.length === 0) {
+    // No row for any wallet in the set: the refresh job has never reached this account, which is
+    // not the same statement as "this account made no money". Reported as such — a wallet that only
+    // ever traded through an executor never lands in `analytics_daily_wallet`, so the miss is a
+    // coverage gap, not an answer.
     const startTime = period === "all" ? null : eodStartTimesForPeriods(endTime, null)[period];
-    return zeros(endTime, startTime, null);
+    return zeros(endTime, startTime, null, false);
   }
 
   let latestUpdatedAt: string | null = null;
@@ -177,6 +188,7 @@ async function portfolioPlFromLeaderboard(args: {
     endTime: snapshotEnd,
     ...summed,
     updatedAt: latestUpdatedAt,
+    computed: true,
     unit: "USD",
   };
 }
@@ -232,6 +244,9 @@ function emptyPortfolioPlSnapshot(args: {
     marketCount: 0,
     capitalDeployed: 0,
     pnl: 0,
+    // Every caller of this is a stand-in for a P/L that was never produced — a compute failure, or
+    // a period the compute did not return. None of them is a measured zero.
+    computed: false,
     ...(marketScoped ? {} : { updatedAt: null, unit: "USD" as const }),
   };
 }
@@ -354,7 +369,8 @@ export default async (req: Request) => {
       });
     }
 
-    const snapshot = computed.byPeriod[period] ?? zeros();
+    const periodSnapshot = computed.byPeriod[period];
+    const snapshot = periodSnapshot ? { ...periodSnapshot, computed: true } : zeros();
     const body: Record<string, unknown> = { ...snapshot };
     if (debug && computed.debugPayload) {
       body.debug = computed.debugPayload;

--- a/web/netlify/functions/get-transactions.mts
+++ b/web/netlify/functions/get-transactions.mts
@@ -1,4 +1,4 @@
-import type { MarketDataMapping, SupportedChain, TransactionData } from "@seer-pm/sdk";
+import type { MarketDataMapping, SupportedChain, Token, TransactionData } from "@seer-pm/sdk";
 import type { Market } from "@seer-pm/sdk/market-types";
 import { type Address, isAddress } from "viem";
 import { fetchLastActivityTimestampForWallets, supportedChainIds } from "./utils/accountLastActivity";
@@ -13,7 +13,8 @@ import {
   writeJsonBlob,
 } from "./utils/portfolioBlobCache";
 import { type PortfolioIdentity, resolvePortfolioIdentity } from "./utils/portfolioIdentity";
-import { conditionalEventsToTransactions, fetchConditionalEventsForAccount } from "./utils/seerIndexerPortfolio";
+import { parseCollateralProfileQueryParam } from "./utils/resolveCollateralParam";
+import { fetchAccountConditionalTransactions } from "./utils/transactions/fetchAccountConditionalEvents";
 import { fetchAccountDexTransactions } from "./utils/transactions/fetchAccountDexEvents";
 
 const PORTFOLIO_TRANSACTIONS_STORE = "portfolio-transactions";
@@ -46,7 +47,21 @@ function jsonOk(body: unknown) {
   });
 }
 
-async function getEvents(mappings: MarketDataMapping | null, account: Address, chainId: SupportedChain) {
+/**
+ * One wallet's rows on one chain, plus whether any source was lost.
+ *
+ * `failed` matters as much as the rows: a source that rejects leaves a partial view, and the caller
+ * counts the wallet as degraded so it is never frozen into the blob. Without that, an indexer blip
+ * on the conditional source caches a swaps-only history for the full TTL — exactly the pre-fix view
+ * the widened ownership exists to eliminate.
+ */
+async function getEvents(
+  mappings: MarketDataMapping | null,
+  account: Address,
+  chainId: SupportedChain,
+  primaryCollateral: Token | undefined,
+  preferMarketIds: string[],
+): Promise<{ events: TransactionData[]; failed: boolean }> {
   const sources: { name: string; promise: Promise<TransactionData[]> }[] = [
     {
       name: "dex",
@@ -54,16 +69,18 @@ async function getEvents(mappings: MarketDataMapping | null, account: Address, c
     },
     {
       name: "conditional",
-      promise: fetchConditionalEventsForAccount(account, chainId).then(conditionalEventsToTransactions),
+      promise: fetchAccountConditionalTransactions(account, chainId, primaryCollateral, preferMarketIds),
     },
   ];
   const results = await Promise.allSettled(sources.map((s) => s.promise));
   const events: TransactionData[] = [];
+  let failed = false;
   for (let i = 0; i < results.length; i++) {
     const result = results[i];
     if (result.status === "fulfilled") {
       events.push(...result.value);
     } else {
+      failed = true;
       console.warn("get-transactions: event source failed", {
         source: sources[i].name,
         chainId,
@@ -71,7 +88,7 @@ async function getEvents(mappings: MarketDataMapping | null, account: Address, c
       });
     }
   }
-  return events;
+  return { events, failed };
 }
 
 /**
@@ -90,6 +107,9 @@ async function getTransactions(
   // the chain. A failed `getMappingsCached` below is chain-wide and does reject.
   const marketResults = await Promise.allSettled(wallets.map((wallet) => loadAccountMarkets(wallet, chainId)));
   const failedWallets: Address[] = [];
+  // Wallets whose markets loaded but whose event sources did not fully answer. Merged into
+  // `failedWallets` below so both kinds of degradation block the cache write.
+  const degradedWallets: Address[] = [];
   const ok: { wallet: Address; markets: Market[] }[] = [];
   marketResults.forEach((result, index) => {
     if (result.status === "fulfilled") {
@@ -110,8 +130,28 @@ async function getTransactions(
   const mappings =
     markets.length === 0 ? null : await getMappingsCached(getPublicClientByChainId(chainId), markets, chainId);
 
+  const collateralResolved = parseCollateralProfileQueryParam(chainId, null);
+  if ("error" in collateralResolved) {
+    console.warn("get-transactions: no primary collateral, CTF ownership stays narrow", {
+      chainId,
+      error: collateralResolved.error,
+    });
+  }
+  const primaryCollateral = "error" in collateralResolved ? undefined : collateralResolved.primaryCollateral;
+
   const perWallet = await Promise.all(
-    ok.map(async ({ wallet }) => (await getEvents(mappings, wallet, chainId)).map((row) => ({ row, wallet }))),
+    ok.map(async ({ wallet, markets: walletMarkets }) => {
+      // The wallet's own market universe, not the merged one: `dedupeConditionalEventLegs` picks a
+      // fanned-out leg's market from this set, and `marketPeriodBuckets` passes the per-wallet set
+      // too. Handing it the union would let a leg land on a market only a sibling executor touched,
+      // and the same redeem would then show under one market here and count under another there.
+      const preferMarketIds = walletMarkets.map((market) => market.id.toLowerCase());
+      const { events, failed } = await getEvents(mappings, wallet, chainId, primaryCollateral, preferMarketIds);
+      if (failed) {
+        degradedWallets.push(wallet);
+      }
+      return events.map((row) => ({ row, wallet }));
+    }),
   );
   const data = perWallet.flat();
 
@@ -142,7 +182,7 @@ async function getTransactions(
       tokenOutSymbol: x.tokenOutSymbol ?? parseSymbol(x.tokenOut),
     };
   });
-  return { transactions, failedWallets, okWallets: ok.length };
+  return { transactions, failedWallets: [...failedWallets, ...degradedWallets], okWallets: ok.length };
 }
 
 /**
@@ -284,10 +324,11 @@ export default async (req: Request) => {
     // — but freshness must be judged over the whole set, or a wallet that only trades through its
     // executor never invalidates its own cache.
     const identity = await resolvePortfolioIdentity(account);
-    // `:v2` marks the executor-merged payload format. Blobs written before executors were merged in
-    // hold account-only rows and carry no version of their own, and freshness is a timestamp
-    // comparison — so without this they read as fresh and serve the pre-fix view for a further TTL.
-    const cacheKey = `${account.toLowerCase()}:v2`;
+    // `:v3` marks the widened CTF ownership. Blobs written before it hold `accountId`-only rows, so
+    // a wallet whose splits and redeems were booked to a relayer has none of them, and freshness is
+    // a timestamp comparison — without this they read as fresh and serve the pre-fix view for a
+    // further TTL. `:v2` did the same for the executor-merged payload format.
+    const cacheKey = `${account.toLowerCase()}:v3`;
     const cached = await readJsonBlob<TransactionsCachePayload>(PORTFOLIO_TRANSACTIONS_STORE, cacheKey);
     let lastActivityTs: number | undefined;
     try {

--- a/web/netlify/functions/utils/conditionalEventOwnership.test.ts
+++ b/web/netlify/functions/utils/conditionalEventOwnership.test.ts
@@ -9,7 +9,11 @@ vi.mock("./envioClient", () => ({
   seerEnvioSdk: () => ({ GetTransfers, GetConditionalEvents }),
 }));
 
-import { fetchConditionalEventsByTransactions, fetchRouterCollateralTransactionHashes } from "./seerIndexerPortfolio";
+import {
+  fetchConditionalEventsByTransactions,
+  fetchConditionalEventsForAccountWidened,
+  fetchRouterCollateralTransactionHashes,
+} from "./seerIndexerPortfolio";
 
 const EXECUTOR = "0x2771980e5252204e526745acf056d4a6e2299df0" as Address;
 const ROUTER = "0x179d8f8c811b8c759c33809dbc6c5cedc62d05dd";
@@ -102,5 +106,69 @@ describe("fetchConditionalEventsByTransactions", () => {
       ConditionalEvent: [{ ...conditionalEvent(TX_A, "0xa"), market: null }],
     });
     expect(await fetchConditionalEventsByTransactions(10 as never, [TX_A])).toEqual([]);
+  });
+});
+
+describe("fetchConditionalEventsForAccountWidened", () => {
+  it("keeps a leg booked to the relayer, which the accountId filter alone drops", async () => {
+    // What the executor's own `accountId` query returns: nothing. `resolveAccountId` booked the
+    // event to the EOA that signed for the relayer.
+    GetConditionalEvents.mockResolvedValueOnce({ ConditionalEvent: [] });
+    GetTransfers.mockResolvedValueOnce({ Transfer: [transfer(TX_A, EXECUTOR, ROUTER)] });
+    GetConditionalEvents.mockResolvedValueOnce({
+      ConditionalEvent: [
+        { ...conditionalEvent(TX_A, "0xaaaa000000000000000000000000000000000001"), accountId: RELAYER },
+      ],
+    });
+
+    const events = await fetchConditionalEventsForAccountWidened(EXECUTOR, 10 as never, PRIMARY);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].transactionHash).toBe(TX_A);
+    expect(events[0].amount).toBe(750n * 10n ** 18n);
+  });
+
+  it("counts a leg both signals find exactly once", async () => {
+    const shared = conditionalEvent(TX_A, "0xaaaa000000000000000000000000000000000001");
+    GetConditionalEvents.mockResolvedValueOnce({ ConditionalEvent: [shared] });
+    GetTransfers.mockResolvedValueOnce({ Transfer: [transfer(TX_A, EXECUTOR, ROUTER)] });
+    GetConditionalEvents.mockResolvedValueOnce({ ConditionalEvent: [shared] });
+
+    const events = await fetchConditionalEventsForAccountWidened(EXECUTOR, 10 as never, PRIMARY);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe(shared.id);
+  });
+
+  it("still returns the accountId legs when no collateral ever moved through a router", async () => {
+    GetConditionalEvents.mockResolvedValueOnce({
+      ConditionalEvent: [conditionalEvent(TX_B, "0xaaaa000000000000000000000000000000000002")],
+    });
+    GetTransfers.mockResolvedValueOnce({ Transfer: [] });
+
+    const events = await fetchConditionalEventsForAccountWidened(EXECUTOR, 10 as never, PRIMARY);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].transactionHash).toBe(TX_B);
+    // No transactions to ask about, so the second query is never issued.
+    expect(GetConditionalEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the same window to both halves of the union", async () => {
+    GetConditionalEvents.mockResolvedValueOnce({ ConditionalEvent: [] });
+    GetTransfers.mockResolvedValueOnce({ Transfer: [transfer(TX_A, EXECUTOR, ROUTER)] });
+    GetConditionalEvents.mockResolvedValueOnce({ ConditionalEvent: [] });
+
+    await fetchConditionalEventsForAccountWidened(EXECUTOR, 10 as never, PRIMARY, {
+      startTime: 100,
+      endTime: 900,
+    });
+
+    const window = { _gt: "100", _lte: "900" };
+    expect(GetConditionalEvents.mock.calls[0][0].where.timestamp).toEqual(window);
+    expect(GetConditionalEvents.mock.calls[1][0].where.timestamp).toEqual(window);
+    // The router scan is cumulative to `endTime`: a split before the window can be what the redeem
+    // inside it settles, and the transaction list is only used to test ownership.
+    expect(GetTransfers.mock.calls[0][0].where.timestamp).toEqual({ _lte: "900" });
   });
 });

--- a/web/netlify/functions/utils/conditionalEventOwnership.test.ts
+++ b/web/netlify/functions/utils/conditionalEventOwnership.test.ts
@@ -184,10 +184,11 @@ describe("fetchConditionalEventsForAccountWidened", () => {
   });
 
   it("keeps both legs of a transaction when both went through the router", async () => {
-    // What makes reading the transaction whole correct: a TradeExecutor has one owner and is signed
-    // by that owner, so a router transaction carries one wallet's operation. The CTF books the
-    // router as the stakeholder for every router-mediated leg, so the guard cannot separate two
-    // wallets here — this test is where that would show if the invariant ever stopped holding.
+    // What makes reading the transaction whole correct: a TradeExecutor's owner is immutable and it
+    // acts only for that owner — whoever signs, owner or session key — and an EOA transaction targets
+    // one executor, so a router transaction carries one wallet's operation. The CTF books the router
+    // as the stakeholder for every router-mediated leg, so the guard cannot separate two wallets
+    // here — this test is where that would show if the invariant ever stopped holding.
     GetConditionalEvents.mockResolvedValueOnce({ ConditionalEvent: [] });
     GetTransfers.mockResolvedValueOnce({ Transfer: [transfer(TX_A, EXECUTOR, ROUTER)] });
     GetConditionalEvents.mockResolvedValueOnce({

--- a/web/netlify/functions/utils/conditionalEventOwnership.test.ts
+++ b/web/netlify/functions/utils/conditionalEventOwnership.test.ts
@@ -10,13 +10,17 @@ vi.mock("./envioClient", () => ({
 }));
 
 import {
+  conditionalEventStakeholderIsForeign,
   fetchConditionalEventsByTransactions,
   fetchConditionalEventsForAccountWidened,
   fetchRouterCollateralTransactionHashes,
 } from "./seerIndexerPortfolio";
 
 const EXECUTOR = "0x2771980e5252204e526745acf056d4a6e2299df0" as Address;
+// The deployed optimism router: the stakeholder guard resolves it through `getRouterAddresses(10)`,
+// so this has to be the real address and not a placeholder.
 const ROUTER = "0x179d8f8c811b8c759c33809dbc6c5cedc62d05dd";
+const OTHER_WALLET = "0x9c8f2c1d2b6d4e0a5f3a7b8c9d0e1f2a3b4c5d6e";
 const RELAYER = "0xda6ada37d7e0c697e1bd18ca0586e342b1c45496";
 const PRIMARY = {
   address: "0xb5b2dc7fd34c249f4be7fb1fcea07950784229e0" as Address,
@@ -37,12 +41,18 @@ function transfer(txHash: string, from: string, to: string) {
   return { transactionHash: txHash, from, to, value: "750000000000000000000", timestamp: "1000" };
 }
 
-function conditionalEvent(txHash: string, marketAddress: string) {
+function conditionalEvent(
+  txHash: string,
+  marketAddress: string,
+  stakeholder = ROUTER,
+  amount = "750000000000000000000",
+) {
   return {
     id: `10:${txHash}-240-10:${marketAddress}`,
     market: { id: `10:${marketAddress}`, address: marketAddress, marketName: "m" },
     eventType: "split",
-    amount: "750000000000000000000",
+    stakeholder,
+    amount,
     collateral: PRIMARY.address,
     timestamp: "1000",
     blockNumber: "1",
@@ -154,6 +164,70 @@ describe("fetchConditionalEventsForAccountWidened", () => {
     expect(GetConditionalEvents).toHaveBeenCalledTimes(1);
   });
 
+  it("drops a leg the CTF booked to another wallet, keeping this wallet's own leg from the same transaction", async () => {
+    // Two distinct legs in one transaction: this wallet's, mediated by the router, and another
+    // wallet's, called straight on the CTF. The transaction filter sweeps in both.
+    GetConditionalEvents.mockResolvedValueOnce({ ConditionalEvent: [] });
+    GetTransfers.mockResolvedValueOnce({ Transfer: [transfer(TX_A, EXECUTOR, ROUTER)] });
+    GetConditionalEvents.mockResolvedValueOnce({
+      ConditionalEvent: [
+        conditionalEvent(TX_A, "0xaaaa000000000000000000000000000000000001"),
+        conditionalEvent(TX_A, "0xaaaa000000000000000000000000000000000002", OTHER_WALLET, "400000000000000000000"),
+      ],
+    });
+
+    const events = await fetchConditionalEventsForAccountWidened(EXECUTOR, 10 as never, PRIMARY);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].marketId).toBe("0xaaaa000000000000000000000000000000000001");
+    expect(events[0].amount).toBe(750n * 10n ** 18n);
+  });
+
+  it("keeps both legs of a transaction when both went through the router", async () => {
+    // What makes reading the transaction whole correct: a TradeExecutor has one owner and is signed
+    // by that owner, so a router transaction carries one wallet's operation. The CTF books the
+    // router as the stakeholder for every router-mediated leg, so the guard cannot separate two
+    // wallets here — this test is where that would show if the invariant ever stopped holding.
+    GetConditionalEvents.mockResolvedValueOnce({ ConditionalEvent: [] });
+    GetTransfers.mockResolvedValueOnce({ Transfer: [transfer(TX_A, EXECUTOR, ROUTER)] });
+    GetConditionalEvents.mockResolvedValueOnce({
+      ConditionalEvent: [
+        conditionalEvent(TX_A, "0xaaaa000000000000000000000000000000000001"),
+        conditionalEvent(TX_A, "0xaaaa000000000000000000000000000000000002", ROUTER, "400000000000000000000"),
+      ],
+    });
+
+    const events = await fetchConditionalEventsForAccountWidened(EXECUTOR, 10 as never, PRIMARY);
+
+    expect(events.map((e) => e.amount)).toEqual([750n * 10n ** 18n, 400n * 10n ** 18n]);
+  });
+
+  it("keeps a leg the wallet booked on the CTF itself, without a router", async () => {
+    GetConditionalEvents.mockResolvedValueOnce({ ConditionalEvent: [] });
+    GetTransfers.mockResolvedValueOnce({ Transfer: [transfer(TX_A, EXECUTOR, ROUTER)] });
+    GetConditionalEvents.mockResolvedValueOnce({
+      ConditionalEvent: [conditionalEvent(TX_A, "0xaaaa000000000000000000000000000000000001", EXECUTOR)],
+    });
+
+    const events = await fetchConditionalEventsForAccountWidened(EXECUTOR, 10 as never, PRIMARY);
+
+    expect(events).toHaveLength(1);
+  });
+
+  it("never applies the stakeholder guard to the accountId half", async () => {
+    // `accountId` is the indexer's own attribution; a foreign stakeholder there is the router case
+    // the union exists to keep, not evidence against ownership.
+    GetConditionalEvents.mockResolvedValueOnce({
+      ConditionalEvent: [conditionalEvent(TX_B, "0xaaaa000000000000000000000000000000000002", OTHER_WALLET)],
+    });
+    GetTransfers.mockResolvedValueOnce({ Transfer: [] });
+
+    const events = await fetchConditionalEventsForAccountWidened(EXECUTOR, 10 as never, PRIMARY);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].transactionHash).toBe(TX_B);
+  });
+
   it("passes the same window to both halves of the union", async () => {
     GetConditionalEvents.mockResolvedValueOnce({ ConditionalEvent: [] });
     GetTransfers.mockResolvedValueOnce({ Transfer: [transfer(TX_A, EXECUTOR, ROUTER)] });
@@ -170,5 +244,32 @@ describe("fetchConditionalEventsForAccountWidened", () => {
     // The router scan is cumulative to `endTime`: a split before the window can be what the redeem
     // inside it settles, and the transaction list is only used to test ownership.
     expect(GetTransfers.mock.calls[0][0].where.timestamp).toEqual({ _lte: "900" });
+  });
+});
+
+describe("conditionalEventStakeholderIsForeign", () => {
+  it("keeps a router-mediated leg — the case the transfer signal resolves", () => {
+    expect(conditionalEventStakeholderIsForeign({ stakeholder: ROUTER }, EXECUTOR, 10 as never)).toBe(false);
+  });
+
+  it("keeps a leg the wallet booked itself, whatever the casing", () => {
+    expect(conditionalEventStakeholderIsForeign({ stakeholder: EXECUTOR.toUpperCase() }, EXECUTOR, 10 as never)).toBe(
+      false,
+    );
+  });
+
+  it("rejects a leg booked to another wallet", () => {
+    expect(conditionalEventStakeholderIsForeign({ stakeholder: OTHER_WALLET }, EXECUTOR, 10 as never)).toBe(true);
+  });
+
+  it("fails open on an empty or zero stakeholder", () => {
+    expect(conditionalEventStakeholderIsForeign({ stakeholder: "" }, EXECUTOR, 10 as never)).toBe(false);
+    expect(
+      conditionalEventStakeholderIsForeign(
+        { stakeholder: "0x0000000000000000000000000000000000000000" },
+        EXECUTOR,
+        10 as never,
+      ),
+    ).toBe(false);
   });
 });

--- a/web/netlify/functions/utils/leaderboardCandidateSources.test.ts
+++ b/web/netlify/functions/utils/leaderboardCandidateSources.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `pnlLeaderboard` pulls in `executorOwners`, which builds a Supabase client at import time.
+// Hoisted so the placeholders are in place before the ESM imports below run. Nothing here reaches
+// the network: the only client that would is the stand-in passed into the function under test.
+vi.hoisted(() => {
+  process.env.SUPABASE_PROJECT_URL ||= "http://supabase.test";
+  process.env.SUPABASE_API_KEY ||= "test-key";
+});
+
+const GetAccountActivitiesByChain = vi.fn();
+
+vi.mock("./envioClient", () => ({
+  seerEnvioSdk: () => ({ GetAccountActivitiesByChain }),
+}));
+
+import { listLeaderboardCandidates } from "./pnlLeaderboard";
+
+const CHAIN = 10;
+const DAY = 86_400;
+
+/** The owner EOA never signs its own trades, so the analytics rollups never name it. */
+const OWNER = "0x02dadbe42f385fa68f96c753df7f24c863701481";
+/** Holds the tokens, so the indexer sees it even though it is never a tx sender. */
+const EXECUTOR = "0x7f93d9e40f0b393d2d5506d618aa0526496f374f";
+/** What `tokens_transfers.tx_from` actually records for those trades. */
+const RELAYER = "0x4d684bbc7296a913f95257b7d5659047031f65e6";
+
+/** Minimal `supabase.from(...).select(...)…range()` chain: analytics returns `rows` once. */
+function supabaseReturning(rows: { address: string; day: number }[]) {
+  const builder: Record<string, unknown> = {};
+  for (const method of ["select", "eq", "in", "gte", "order"]) {
+    builder[method] = () => builder;
+  }
+  builder.range = (from: number) => Promise.resolve({ data: from === 0 ? rows : [], error: null });
+  // biome-ignore lint/suspicious/noExplicitAny: hand-rolled stand-in for the query builder
+  return { from: () => builder } as any;
+}
+
+function activityRow(account: string, lastTransferTimestamp: number) {
+  return {
+    id: `${CHAIN}:${account}`,
+    chainId: String(CHAIN),
+    account,
+    earliestTransferTimestamp: "0",
+    lastTransferTimestamp: String(lastTransferTimestamp),
+    transferCount: "1",
+  };
+}
+
+beforeEach(() => {
+  GetAccountActivitiesByChain.mockReset();
+});
+
+describe("listLeaderboardCandidates", () => {
+  it("reaches a wallet that only ever traded through a relayer-driven executor", async () => {
+    GetAccountActivitiesByChain.mockResolvedValueOnce({
+      AccountActivity: [activityRow(EXECUTOR, 10 * DAY + 500)],
+    });
+
+    const candidates = await listLeaderboardCandidates(
+      supabaseReturning([{ address: RELAYER, day: 9 * DAY }]),
+      CHAIN,
+      undefined,
+      {
+        cutoffDay: 0,
+      },
+    );
+
+    const addresses = candidates.map((c) => c.address);
+    // The executor is the whole point: analytics only ever saw the relayer that signed for it.
+    expect(addresses).toContain(EXECUTOR);
+    expect(addresses).toContain(RELAYER);
+    expect(addresses).not.toContain(OWNER);
+    // Timestamps arrive in seconds and have to land on the same UTC-day grain as the analytics half.
+    expect(candidates.find((c) => c.address === EXECUTOR)?.lastActivityDay).toBe(10 * DAY);
+  });
+
+  it("keeps the latest activity day when both sources name the same wallet", async () => {
+    GetAccountActivitiesByChain.mockResolvedValueOnce({
+      AccountActivity: [activityRow(RELAYER, 12 * DAY)],
+    });
+
+    const candidates = await listLeaderboardCandidates(
+      supabaseReturning([{ address: RELAYER, day: 9 * DAY }]),
+      CHAIN,
+      undefined,
+      {
+        cutoffDay: 0,
+      },
+    );
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].lastActivityDay).toBe(12 * DAY);
+  });
+
+  it("still returns the analytics half when the indexer scan fails", async () => {
+    GetAccountActivitiesByChain.mockRejectedValueOnce(new Error("indexer down"));
+
+    const candidates = await listLeaderboardCandidates(
+      supabaseReturning([{ address: RELAYER, day: 9 * DAY }]),
+      CHAIN,
+      undefined,
+      {
+        cutoffDay: 0,
+      },
+    );
+
+    // Degrading to the old coverage beats blanking a board the analytics half could refresh.
+    expect(candidates.map((c) => c.address)).toEqual([RELAYER]);
+  });
+
+  it("leaves market-scoped jobs on the analytics source alone", async () => {
+    const candidates = await listLeaderboardCandidates(
+      supabaseReturning([{ address: RELAYER, day: 9 * DAY }]),
+      CHAIN,
+      ["0xaaaa000000000000000000000000000000000001"],
+      { cutoffDay: 0 },
+    );
+
+    expect(candidates.map((c) => c.address)).toEqual([RELAYER]);
+    expect(GetAccountActivitiesByChain).not.toHaveBeenCalled();
+  });
+});

--- a/web/netlify/functions/utils/pnlLeaderboard.ts
+++ b/web/netlify/functions/utils/pnlLeaderboard.ts
@@ -25,7 +25,7 @@ import {
   deriveOwnerGroupRows,
 } from "./pnlMarketRows";
 import { PORTFOLIO_PL_PERIODS, computePortfolioPlAllPeriods } from "./portfolioPlCompute";
-import type { PortfolioPlPeriod } from "./seerIndexerPortfolio";
+import { type PortfolioPlPeriod, fetchChainAccountActivities, floorUtcDay } from "./seerIndexerPortfolio";
 import type { Database, TablesInsert } from "./supabase";
 import type { OwnerMap } from "./tradeExecutorOwnersCore";
 
@@ -72,6 +72,20 @@ export function recentActivityCutoffDay(
 /**
  * Every wallet with analytics activity in the last `PNL_LEADERBOARD_RECENT_DAYS` UTC days.
  * When `marketIds` is omitted, uses the whole chain (All / protocol-wide).
+ *
+ * The protocol-wide list is the union of two sources that see different things, and the P/L job
+ * needs both:
+ *
+ * - **Supabase analytics** (`analytics_daily_wallet`) is keyed by `tokens_transfers.tx_from`,
+ *   i.e. msg.sender. That is the right grain for the dashboard's "unique wallets", and the wrong
+ *   one here: a TradeExecutor called by a relayer books the *relayer*, so neither the executor
+ *   holding the tokens nor the owner it belongs to is ever named. `withExecutors` cannot rescue
+ *   them either — it only synthesizes an executor for an owner already in the list.
+ * - **Indexer `AccountActivity`** is keyed by transfer counterparty, so the executor appears
+ *   under its own address and `canonicalAddress` rolls it onto its owner at read time.
+ *
+ * Market-scoped jobs keep the analytics-only path: the indexer view has no market dimension to
+ * filter on, and widening those boards is not what this fixes.
  */
 export async function listLeaderboardCandidates(
   supabase: SupabaseClient<Database>,
@@ -90,11 +104,47 @@ export async function listLeaderboardCandidates(
   const cutoffDay = opts?.cutoffDay ?? recentActivityCutoffDay();
 
   if (marketIds === undefined) {
-    return listCandidatesFromWalletAnalytics(supabase, chainId, cutoffDay);
+    const [fromAnalytics, fromIndexer] = await Promise.all([
+      listCandidatesFromWalletAnalytics(supabase, chainId, cutoffDay),
+      // Additive and best-effort: the indexer being down must not shrink the candidate list to
+      // nothing and blank out a board that the analytics half could still have refreshed.
+      listCandidatesFromIndexerActivity(chainId, cutoffDay).catch((error) => {
+        console.warn("pnl-leaderboard: indexer candidate scan failed", { chainId, error });
+        return [] as LeaderboardCandidate[];
+      }),
+    ]);
+    return mergeCandidates(fromAnalytics, fromIndexer);
   }
   if (marketIds.length === 0) return [];
 
   return listCandidatesFromAnalytics(supabase, chainId, marketIds, cutoffDay);
+}
+
+/** Union two candidate lists, keeping the most recent activity day seen for each address. */
+function mergeCandidates(...lists: LeaderboardCandidate[][]): LeaderboardCandidate[] {
+  const lastDayByAddress = new Map<string, number>();
+  for (const list of lists) {
+    for (const candidate of list) {
+      const address = candidate.address.toLowerCase();
+      if (!address || address === ZERO_ADDRESS) continue;
+      lastDayByAddress.set(address, Math.max(lastDayByAddress.get(address) ?? 0, candidate.lastActivityDay ?? 0));
+    }
+  }
+  return [...lastDayByAddress].map(([address, lastActivityDay]) => ({ address, lastActivityDay }));
+}
+
+/**
+ * Candidates from the indexer's holder-side activity.
+ *
+ * `lastTransferTimestamp` is floored to its UTC day so `lastActivityDay` stays the same unit the
+ * analytics half produces — `rankRefreshCandidates` compares the two against each other.
+ */
+async function listCandidatesFromIndexerActivity(chainId: number, cutoffDay: number): Promise<LeaderboardCandidate[]> {
+  const rows = await fetchChainAccountActivities(chainId as SupportedChain, cutoffDay);
+  return rows.map((row) => ({
+    address: row.account,
+    lastActivityDay: floorUtcDay(row.lastTransferTimestamp),
+  }));
 }
 
 const CANDIDATE_PAGE_SIZE = 1000;

--- a/web/netlify/functions/utils/portfolioPlCompute.ts
+++ b/web/netlify/functions/utils/portfolioPlCompute.ts
@@ -23,10 +23,8 @@ import {
   computeCollateralPortfolioValuesForPeriods,
   eodStartTimesForPeriods,
   fetchAccountActivity,
-  fetchConditionalEventsByTransactions,
-  fetchConditionalEventsForAccount,
+  fetchConditionalEventsForAccountWidened,
   fetchMarketIdsFromAccountTransfers,
-  fetchRouterCollateralTransactionHashes,
   fetchRouterPrimaryCollateralTransfers,
   fetchTokenBalances,
   fetchTokenBalancesAtEods,
@@ -236,30 +234,16 @@ async function fetchScopedConditionalEvents(
   const marketSet = new Set(markets.map((m) => m.id.toLowerCase()));
   const minStart = Math.min(...PORTFOLIO_PL_PERIODS.map((p) => startTimeByPeriod[p]));
 
-  const byAccount = await fetchConditionalEventsForAccount(account, chainId, {
+  const events = await fetchConditionalEventsForAccountWidened(account, chainId, primaryCollateral, {
     startTime: minStart,
     endTime,
     marketAddresses: [...marketSet] as Address[],
-  });
-
-  const routerTxHashes = await fetchRouterCollateralTransactionHashes(
-    account,
-    chainId,
-    primaryCollateral,
-    endTime,
     routerTransfers,
-  );
-  const byTransaction = await fetchConditionalEventsByTransactions(chainId, routerTxHashes, {
-    startTime: minStart,
-    endTime,
   });
 
-  const byId = new Map<string, ConditionalEventRow>();
-  for (const event of [...byAccount, ...byTransaction]) {
-    if (!marketSet.has(event.marketId.toLowerCase())) continue;
-    byId.set(event.id, event);
-  }
-  return [...byId.values()];
+  // The by-transaction half of the union is not market-filtered at the query — a router transaction
+  // can carry legs of markets outside this scope — so the scope is applied here.
+  return events.filter((event) => marketSet.has(event.marketId.toLowerCase()));
 }
 
 function reconstructRouterLegsByPeriod(

--- a/web/netlify/functions/utils/portfolioPlCompute.ts
+++ b/web/netlify/functions/utils/portfolioPlCompute.ts
@@ -222,10 +222,11 @@ type RouterLegs = {
  *
  * Ownership is the union of two signals, because neither alone is complete:
  *
- * - `accountId` — right when the user signed their own transaction.
+ * - `accountId` — the indexer's attribution: `transaction.to` since `seer-indexer` `0261506`, the
+ *   signer before it. Right for a direct call either way; wrong for a TradeExecutor driven by a
+ *   session key on rows indexed before that change, and for any intermediary contract still.
  * - the transactions where **primary collateral actually moved** between the account and a router —
- *   the only signal that survives a TradeExecutor driven by a relayer, where `resolveAccountId`
- *   books the event to the signing EOA instead of to the executor whose money moved.
+ *   the signal that follows the money whatever the indexer booked.
  *
  * Deduped by event id, so a leg that both signals find is counted once. Amounts and markets always
  * come from the event itself; only the ownership test is widened.

--- a/web/netlify/functions/utils/portfolioPlCompute.ts
+++ b/web/netlify/functions/utils/portfolioPlCompute.ts
@@ -67,6 +67,15 @@ export type PortfolioPlPeriodSnapshot = {
   /** Snapshot write time from `pnl_leaderboard.updated_at` (global path). */
   updatedAt?: string | null;
   /**
+   * Global path only: false when no `pnl_leaderboard` row exists for any wallet in the set.
+   *
+   * The zeros returned on that miss are not a measurement — the refresh job has simply never
+   * reached this wallet — and a consumer that renders them as `$0` states a P/L the system never
+   * computed. `updatedAt: null` already carried the distinction; this names it so callers do not
+   * have to infer it from a timestamp.
+   */
+  computed?: boolean;
+  /**
    * The cumulative router-collateral half of `value*` on the global path, broken out.
    *
    * Reported separately so `value* − collateral*` gives the outcome-MTM half **independently**,

--- a/web/netlify/functions/utils/seerIndexerPortfolio.ts
+++ b/web/netlify/functions/utils/seerIndexerPortfolio.ts
@@ -504,6 +504,55 @@ export async function fetchConditionalEventsByTransactions(
   return out;
 }
 
+/**
+ * Split/merge/redeem legs belonging to this account, under the union of both ownership signals.
+ *
+ * Neither signal alone is complete:
+ *
+ * - `accountId` — right when the user signed their own transaction.
+ * - the transactions where **primary collateral actually moved** between the account and a router —
+ *   the only signal that survives a TradeExecutor driven by a relayer, where `resolveAccountId`
+ *   books the event to the signing EOA instead of to the executor whose money moved.
+ *
+ * Deduped by event id, so a leg that both signals find is counted once. Amounts and markets always
+ * come from the event itself; only the ownership test is widened. Callers that need per-market sums
+ * must still collapse the indexer's market fan-out with `dedupeConditionalEventLegs`.
+ */
+export async function fetchConditionalEventsForAccountWidened(
+  account: Address,
+  chainId: SupportedChain,
+  primaryCollateral: Token,
+  opts?: {
+    startTime?: number;
+    endTime?: number;
+    marketAddresses?: Address[];
+    /** Pass an already-fetched router-collateral scan to skip re-paginating it. */
+    routerTransfers?: RouterCollateralTransfer[];
+  },
+): Promise<ConditionalEventRow[]> {
+  const endTime = opts?.endTime ?? Math.floor(Date.now() / 1000);
+  const window = { startTime: opts?.startTime, endTime };
+
+  // The two signals are independent, so they are asked for together — this runs per wallet per chain
+  // on a cache miss, inside a synchronous function.
+  const [byAccount, routerTxHashes] = await Promise.all([
+    fetchConditionalEventsForAccount(account, chainId, {
+      ...window,
+      marketAddresses: opts?.marketAddresses,
+    }),
+    // The transfer follows the money, so its transactions are the reliable ownership signal; the
+    // events in them are then read whole, since one router transaction is one user's operation.
+    fetchRouterCollateralTransactionHashes(account, chainId, primaryCollateral, endTime, opts?.routerTransfers),
+  ]);
+  const byTransaction = await fetchConditionalEventsByTransactions(chainId, routerTxHashes, window);
+
+  const byId = new Map<string, ConditionalEventRow>();
+  for (const event of [...byAccount, ...byTransaction]) {
+    byId.set(event.id, event);
+  }
+  return [...byId.values()];
+}
+
 export function conditionalEventsToTransactions(events: ConditionalEventRow[]): TransactionData[] {
   return events.map((ev) => {
     const base = {

--- a/web/netlify/functions/utils/seerIndexerPortfolio.ts
+++ b/web/netlify/functions/utils/seerIndexerPortfolio.ts
@@ -65,6 +65,56 @@ export async function fetchAccountActivities(account: Address): Promise<AccountA
   return rows.map(mapAccountActivityRow);
 }
 
+/** One indexed address on a chain, with the day of its last token movement. */
+export type ChainAccountActivity = {
+  account: string;
+  lastTransferTimestamp: number;
+};
+
+/** Bound the scan so a runaway page loop cannot eat a background function's whole budget. */
+const MAX_ACCOUNT_ACTIVITY_PAGES = 100;
+
+/**
+ * Every address the indexer has seen move an indexed token on `chainId`, paged.
+ *
+ * This is the *holder* view — `AccountActivity` is written from `Transfer.from` / `Transfer.to` —
+ * which is what makes it complementary to the Supabase analytics rollups the P/L job otherwise
+ * uses. Those are keyed by `tokens_transfers.tx_from`, i.e. msg.sender, so a TradeExecutor driven
+ * by a relayer books the *relayer* and neither the executor nor its owner ever appears. The
+ * executor does appear here, because the tokens really move to it.
+ *
+ * Ordered by `id` (`chainId:account`, unique) so offset paging is stable.
+ */
+export async function fetchChainAccountActivities(
+  chainId: SupportedChain,
+  minLastTransferTimestamp = 0,
+): Promise<ChainAccountActivity[]> {
+  const sdk = seerEnvioSdk(chainId);
+  const out: ChainAccountActivity[] = [];
+  let offset = 0;
+  for (let page = 0; page < MAX_ACCOUNT_ACTIVITY_PAGES; page++) {
+    const { AccountActivity: rows } = await sdk.GetAccountActivitiesByChain({
+      limit: PAGE,
+      offset,
+      orderBy: [{ id: Order_By.Asc }],
+      where: {
+        chainId: { _eq: String(chainId) },
+        ...(minLastTransferTimestamp > 0 ? { lastTransferTimestamp: { _gte: String(minLastTransferTimestamp) } } : {}),
+      },
+    });
+    for (const row of rows) {
+      out.push({
+        account: row.account.toLowerCase(),
+        lastTransferTimestamp: Number(row.lastTransferTimestamp),
+      });
+    }
+    if (rows.length < PAGE) return out;
+    offset += PAGE;
+  }
+  console.warn("seerIndexerPortfolio: account activity scan hit the page cap", { chainId, scanned: out.length });
+  return out;
+}
+
 /**
  * Distinct market addresses from this account's indexed transfers (outcome / router legs).
  * Used when head holdings are empty so swap/LP cashflow can still load historical markets.

--- a/web/netlify/functions/utils/seerIndexerPortfolio.ts
+++ b/web/netlify/functions/utils/seerIndexerPortfolio.ts
@@ -379,12 +379,14 @@ export async function computeCollateralPortfolioValuesForPeriods(
  * Transactions where primary collateral moved between this account and a Seer router.
  *
  * Needed because `ConditionalEvent.accountId` does **not** always identify the economic owner. When
- * the CTF stakeholder is the router, the indexer rewrites `accountId` to `transaction.from`
- * (`resolveAccountId`). That is right when the user signs their own transaction, but a DeepFunding
- * TradeExecutor is driven by a relayer: the collateral leaves the executor while the event is booked
- * to whichever EOA happened to sign. Measured on optimism, 127 of 366 router transfers with an
- * associated event (35%, across 74 addresses) are attributed to an address other than the one whose
- * collateral moved.
+ * the CTF stakeholder is the router, the event does not carry the router's caller and the indexer
+ * has to pick one (`resolveAccountId`). Rows indexed before `seer-indexer` `0261506` carry
+ * `transaction.from`: right when the user signed their own transaction, wrong for a DeepFunding
+ * TradeExecutor driven by a session key, where the collateral leaves the executor while the event is
+ * booked to a throwaway EOA. Measured on optimism, 127 of 366 router transfers with an associated
+ * event (35%, across 74 addresses) were attributed to an address other than the one whose collateral
+ * moved. Rows indexed after it carry `transaction.to` — the executor or contract wallet itself — but
+ * a forwarder or module between that recipient and the router is still booked to the intermediary.
  *
  * The `Transfer` follows the money, so its transactions are the reliable ownership signal. The event
  * is still the source of the amount and the market — only the ownership test changes.
@@ -605,10 +607,11 @@ export function conditionalEventStakeholderIsForeign(
  *
  * Neither signal alone is complete:
  *
- * - `accountId` — right when the user signed their own transaction.
+ * - `accountId` — the indexer's attribution: `transaction.to` since `seer-indexer` `0261506`, the
+ *   signer before it. Right for a direct call either way; wrong for a TradeExecutor driven by a
+ *   session key on rows indexed before that change, and for any intermediary contract still.
  * - the transactions where **primary collateral actually moved** between the account and a router —
- *   the only signal that survives a TradeExecutor driven by a relayer, where `resolveAccountId`
- *   books the event to the signing EOA instead of to the executor whose money moved.
+ *   the signal that follows the money whatever the indexer booked.
  *
  * Deduped by event id, so a leg that both signals find is counted once. Amounts and markets always
  * come from the event itself; only the ownership test is widened. The transaction signal is narrowed

--- a/web/netlify/functions/utils/seerIndexerPortfolio.ts
+++ b/web/netlify/functions/utils/seerIndexerPortfolio.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_CHAIN } from "@/lib/chains";
 import type { PortfolioPosition, SupportedChain, Token, TransactionData } from "@seer-pm/sdk";
+import { getRouterAddresses } from "@seer-pm/sdk";
 import { unescapeJson } from "@seer-pm/sdk/market";
 import { Order_By } from "@seer-pm/sdk/subgraph/seer";
 import { type Address, formatUnits } from "viem";
@@ -360,6 +361,11 @@ export type ConditionalEventRow = {
   marketEntityId: string;
   marketName: string;
   eventType: "split" | "merge" | "redeem";
+  /**
+   * CTF-level party: a router when the leg went through one, the wallet itself for a direct call.
+   * Optional because only the ownership guard reads it, and that guard fails open without it.
+   */
+  stakeholder?: string;
   amount: bigint;
   collateral: Address;
   timestamp: number;
@@ -434,6 +440,7 @@ export async function fetchConditionalEventsForAccount(
           marketEntityId: row.market.id,
           marketName: unescapeJson(row.market.marketName),
           eventType: row.eventType as "split" | "merge" | "redeem",
+          stakeholder: row.stakeholder,
           amount: BigInt(row.amount),
           collateral: row.collateral as Address,
           timestamp: Number(row.timestamp),
@@ -490,6 +497,7 @@ export async function fetchConditionalEventsByTransactions(
           marketEntityId: row.market.id,
           marketName: unescapeJson(row.market.marketName),
           eventType: row.eventType as "split" | "merge" | "redeem",
+          stakeholder: row.stakeholder,
           amount: BigInt(row.amount),
           collateral: row.collateral as Address,
           timestamp: Number(row.timestamp),
@@ -504,6 +512,44 @@ export async function fetchConditionalEventsByTransactions(
   return out;
 }
 
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+const routerAddressSetByChain = new Map<number, Set<string>>();
+
+/** Lowercased Seer routers on `chainId`, built once — the guard runs per event. */
+function routerAddressSet(chainId: SupportedChain): Set<string> {
+  let set = routerAddressSetByChain.get(chainId);
+  if (!set) {
+    set = new Set(getRouterAddresses(chainId).map((router) => router.toLowerCase()));
+    routerAddressSetByChain.set(chainId, set);
+  }
+  return set;
+}
+
+/**
+ * Positive evidence that a leg found *by transaction* is someone else's.
+ *
+ * `stakeholder` is the CTF-level party, the raw event field `resolveAccountId` never rewrites: a
+ * router when the leg went through one — the case the transfer signal exists to resolve — and the
+ * wallet itself for a direct CTF call. Sampled against the indexer, every event whose stakeholder
+ * is not a router carries `accountId === stakeholder` (6k rows, two stakeholders, one `accountId`
+ * each), so a foreign non-router stakeholder names the real owner and this leg was only swept in by
+ * the transaction filter.
+ *
+ * Fails open: an empty or zero stakeholder keeps the leg and leaves ownership to the transfer
+ * signal, rather than dropping a leg on a guess.
+ */
+export function conditionalEventStakeholderIsForeign(
+  event: Pick<ConditionalEventRow, "stakeholder">,
+  account: Address,
+  chainId: SupportedChain,
+): boolean {
+  const stakeholder = event.stakeholder?.toLowerCase();
+  if (!stakeholder || stakeholder === ZERO_ADDRESS) return false;
+  if (stakeholder === account.toLowerCase()) return false;
+  return !routerAddressSet(chainId).has(stakeholder);
+}
+
 /**
  * Split/merge/redeem legs belonging to this account, under the union of both ownership signals.
  *
@@ -515,8 +561,10 @@ export async function fetchConditionalEventsByTransactions(
  *   books the event to the signing EOA instead of to the executor whose money moved.
  *
  * Deduped by event id, so a leg that both signals find is counted once. Amounts and markets always
- * come from the event itself; only the ownership test is widened. Callers that need per-market sums
- * must still collapse the indexer's market fan-out with `dedupeConditionalEventLegs`.
+ * come from the event itself; only the ownership test is widened. The transaction signal is narrowed
+ * back by `conditionalEventStakeholderIsForeign`, which drops a leg the CTF booked to a third party.
+ * Callers that need per-market sums must still collapse the indexer's market fan-out with
+ * `dedupeConditionalEventLegs`.
  */
 export async function fetchConditionalEventsForAccountWidened(
   account: Address,
@@ -540,11 +588,16 @@ export async function fetchConditionalEventsForAccountWidened(
       ...window,
       marketAddresses: opts?.marketAddresses,
     }),
-    // The transfer follows the money, so its transactions are the reliable ownership signal; the
-    // events in them are then read whole, since one router transaction is one user's operation.
+    // The transfer follows the money, so its transactions are the reliable ownership signal.
     fetchRouterCollateralTransactionHashes(account, chainId, primaryCollateral, endTime, opts?.routerTransfers),
   ]);
-  const byTransaction = await fetchConditionalEventsByTransactions(chainId, routerTxHashes, window);
+  // Those transactions are then read whole, because one router transaction carries one wallet's
+  // operation: a TradeExecutor belongs to a single owner and is signed by that owner, so no relayer
+  // ever batches two wallets into one transaction. `stakeholder` still rejects the one leg that
+  // assumption does not cover — a third party calling the CTF directly in the same transaction.
+  const byTransaction = (await fetchConditionalEventsByTransactions(chainId, routerTxHashes, window)).filter(
+    (event) => !conditionalEventStakeholderIsForeign(event, account, chainId),
+  );
 
   const byId = new Map<string, ConditionalEventRow>();
   for (const event of [...byAccount, ...byTransaction]) {

--- a/web/netlify/functions/utils/seerIndexerPortfolio.ts
+++ b/web/netlify/functions/utils/seerIndexerPortfolio.ts
@@ -642,9 +642,11 @@ export async function fetchConditionalEventsForAccountWidened(
     fetchRouterCollateralTransactionHashes(account, chainId, primaryCollateral, endTime, opts?.routerTransfers),
   ]);
   // Those transactions are then read whole, because one router transaction carries one wallet's
-  // operation: a TradeExecutor belongs to a single owner and is signed by that owner, so no relayer
-  // ever batches two wallets into one transaction. `stakeholder` still rejects the one leg that
-  // assumption does not cover — a third party calling the CTF directly in the same transaction.
+  // operation. Not because of who signs it: a DeepFunding TradeExecutor can be driven by a
+  // temporary session key (`setTemporaryPermission`), so the signer is often not the owner. It holds
+  // because the executor's `owner` is immutable and `batchExecute` acts only for it, whoever calls,
+  // and an EOA transaction targets one executor. `stakeholder` still rejects the one leg that does
+  // not cover — a third party calling the CTF directly in the same transaction.
   const byTransaction = (await fetchConditionalEventsByTransactions(chainId, routerTxHashes, window)).filter(
     (event) => !conditionalEventStakeholderIsForeign(event, account, chainId),
   );

--- a/web/netlify/functions/utils/transactions/fetchAccountConditionalEvents.test.ts
+++ b/web/netlify/functions/utils/transactions/fetchAccountConditionalEvents.test.ts
@@ -1,0 +1,87 @@
+import type { Token } from "@seer-pm/sdk";
+import type { Address } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const GetTransfers = vi.fn();
+const GetConditionalEvents = vi.fn();
+
+vi.mock("../envioClient", () => ({
+  seerEnvioSdk: () => ({ GetTransfers, GetConditionalEvents }),
+}));
+
+import { fetchAccountConditionalTransactions } from "./fetchAccountConditionalEvents";
+
+const EXECUTOR = "0x2771980e5252204e526745acf056d4a6e2299df0" as Address;
+const ROUTER = "0x179d8f8c811b8c759c33809dbc6c5cedc62d05dd";
+const PRIMARY = {
+  address: "0xb5b2dc7fd34c249f4be7fb1fcea07950784229e0" as Address,
+  chainId: 10,
+  decimals: 18,
+  symbol: "sUSDS",
+  name: "sUSDS",
+} as Token;
+const TX_A = "0xe303e6cd0b7fad5e3c30e2e202e1c30c78288b96c89cceafb87414bd712dc836";
+const MARKET_A = "0xaaaa000000000000000000000000000000000001";
+const MARKET_B = "0xaaaa000000000000000000000000000000000002";
+
+beforeEach(() => {
+  GetTransfers.mockReset();
+  GetConditionalEvents.mockReset();
+});
+
+/** One CTF event as the indexer fans it out: same leg, one row per market sharing the condition. */
+function fannedOutLeg(eventType: string, marketAddress: string) {
+  return {
+    id: `10:${TX_A}-240-10:${marketAddress}`,
+    market: { id: `10:${marketAddress}`, address: marketAddress, marketName: "m" },
+    eventType,
+    amount: "750000000000000000000",
+    collateral: PRIMARY.address,
+    timestamp: "1000",
+    blockNumber: "1",
+    transactionHash: TX_A,
+  };
+}
+
+describe("fetchAccountConditionalTransactions", () => {
+  it("renders a fanned-out redeem as one row, not one per duplicate market", async () => {
+    GetConditionalEvents.mockResolvedValueOnce({
+      ConditionalEvent: [fannedOutLeg("redeem", MARKET_A), fannedOutLeg("redeem", MARKET_B)],
+    });
+    GetTransfers.mockResolvedValueOnce({ Transfer: [] });
+
+    const rows = await fetchAccountConditionalTransactions(EXECUTOR, 10 as never, PRIMARY, [MARKET_B]);
+
+    expect(rows).toHaveLength(1);
+    // The endpoint dedupes by `eventId`, and the fan-out ids differ — so the collapse has to happen
+    // here or the same redeem renders twice.
+    expect(rows[0].marketId).toBe(MARKET_B);
+    expect(rows[0].type).toBe("redeem");
+    expect(rows[0].payout).toBe("750000000000000000000");
+  });
+
+  it("surfaces a leg the relayer was booked as, found through the router transfer", async () => {
+    GetConditionalEvents.mockResolvedValueOnce({ ConditionalEvent: [] });
+    GetTransfers.mockResolvedValueOnce({
+      Transfer: [{ transactionHash: TX_A, from: EXECUTOR, to: ROUTER, value: "1", timestamp: "1000" }],
+    });
+    GetConditionalEvents.mockResolvedValueOnce({ ConditionalEvent: [fannedOutLeg("split", MARKET_A)] });
+
+    const rows = await fetchAccountConditionalTransactions(EXECUTOR, 10 as never, PRIMARY);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].type).toBe("split");
+    expect(rows[0].amount).toBe("750000000000000000000");
+  });
+
+  it("stays on the accountId read when the chain has no primary collateral", async () => {
+    GetConditionalEvents.mockResolvedValueOnce({ ConditionalEvent: [fannedOutLeg("merge", MARKET_A)] });
+
+    const rows = await fetchAccountConditionalTransactions(EXECUTOR, 10 as never, undefined);
+
+    expect(rows).toHaveLength(1);
+    // No collateral to follow means no router scan at all, rather than an empty result.
+    expect(GetTransfers).not.toHaveBeenCalled();
+    expect(GetConditionalEvents.mock.calls[0][0].where.accountId).toEqual({ _eq: EXECUTOR });
+  });
+});

--- a/web/netlify/functions/utils/transactions/fetchAccountConditionalEvents.ts
+++ b/web/netlify/functions/utils/transactions/fetchAccountConditionalEvents.ts
@@ -1,0 +1,43 @@
+import type { SupportedChain, Token, TransactionData } from "@seer-pm/sdk";
+import type { Address } from "viem";
+import {
+  conditionalEventsToTransactions,
+  dedupeConditionalEventLegs,
+  fetchConditionalEventsForAccount,
+  fetchConditionalEventsForAccountWidened,
+} from "../seerIndexerPortfolio";
+
+/**
+ * CTF rows (split / merge / redeem) for one wallet, the history counterpart of the DEX source.
+ *
+ * Ownership is the union the P/L compute already uses, not `accountId` alone. `accountId` is not the
+ * economic owner: a TradeExecutor driven by a relayer has its events booked to whichever EOA signed,
+ * so the wallet's own splits and redeems never matched the filter and the History tab showed swaps
+ * only — while the same legs counted in the P/L behind the header. Without a primary collateral
+ * there is no router transfer to follow, so that chain falls back to the narrow read rather than
+ * losing its rows.
+ *
+ * The market fan-out is collapsed here because the endpoint's `transactionKey` cannot: it dedupes by
+ * `eventId`, and the indexer's duplicate legs carry distinct ids (`…-{marketEntityId}`), so one
+ * redeem would render up to five times. `preferMarketIds` should be *this wallet's* own market
+ * universe, matching what `marketPeriodBuckets` passes, so a fanned-out leg lands on the same market
+ * here as in the per-market P/L. Handing it a set merged across wallets would let a leg land on a
+ * market only a sibling executor touched, and the same redeem would then be shown under one market
+ * and counted under another.
+ *
+ * Known limit, inherited from the P/L: reading a router transaction whole assumes it carries one
+ * user's operation. It holds for the relayers seen so far — the deduped leg amounts reconcile
+ * exactly against the account's own router transfers — but a relayer that ever batched two
+ * executors into one transaction would show each the other's rows.
+ */
+export async function fetchAccountConditionalTransactions(
+  account: Address,
+  chainId: SupportedChain,
+  primaryCollateral: Token | undefined,
+  preferMarketIds: string[] = [],
+): Promise<TransactionData[]> {
+  const events = primaryCollateral
+    ? await fetchConditionalEventsForAccountWidened(account, chainId, primaryCollateral)
+    : await fetchConditionalEventsForAccount(account, chainId);
+  return conditionalEventsToTransactions(dedupeConditionalEventLegs(events, preferMarketIds).events);
+}

--- a/web/netlify/functions/utils/transactions/fetchAccountConditionalEvents.ts
+++ b/web/netlify/functions/utils/transactions/fetchAccountConditionalEvents.ts
@@ -26,13 +26,17 @@ import {
  * and counted under another.
  *
  * Reading a router transaction whole is correct because one router transaction carries one wallet's
- * operation: a TradeExecutor belongs to a single owner and is signed by that owner, so nothing
- * batches two wallets into one transaction, and the deduped leg amounts reconcile exactly against
- * the account's own router transfers. `conditionalEventStakeholderIsForeign` covers the case that
- * invariant does not — a third party calling the CTF directly in the same transaction — but it
- * cannot separate two wallets that both went through the router, since the CTF books the router as
- * the stakeholder for both. A relayer that ever drove two wallets in one transaction would need
- * ownership resolved per leg, against the parties of that transaction's collateral transfers.
+ * operation. That does not rest on who signs it — a DeepFunding TradeExecutor accepts calls from a
+ * temporary session key as well as its owner (`setTemporaryPermission`), and the key is what the
+ * indexer books as `accountId`. It rests on the executor's `owner` being immutable, `batchExecute`
+ * acting only for that owner whoever calls it, and an EOA transaction targeting one executor; the
+ * deduped leg amounts reconcile exactly against the account's own router transfers.
+ * `conditionalEventStakeholderIsForeign` covers the case that does not — a third party calling the
+ * CTF directly in the same transaction — but it cannot separate two wallets that both went through
+ * the router, since the CTF books the router as the stakeholder for both. The one way to get there
+ * is a *contract* permitted on several executors batching them in one transaction; the app only
+ * ever permits a fresh EOA, and none has been seen. It would need ownership resolved per leg,
+ * against the parties of that transaction's collateral transfers.
  */
 export async function fetchAccountConditionalTransactions(
   account: Address,

--- a/web/netlify/functions/utils/transactions/fetchAccountConditionalEvents.ts
+++ b/web/netlify/functions/utils/transactions/fetchAccountConditionalEvents.ts
@@ -25,10 +25,14 @@ import {
  * market only a sibling executor touched, and the same redeem would then be shown under one market
  * and counted under another.
  *
- * Known limit, inherited from the P/L: reading a router transaction whole assumes it carries one
- * user's operation. It holds for the relayers seen so far — the deduped leg amounts reconcile
- * exactly against the account's own router transfers — but a relayer that ever batched two
- * executors into one transaction would show each the other's rows.
+ * Reading a router transaction whole is correct because one router transaction carries one wallet's
+ * operation: a TradeExecutor belongs to a single owner and is signed by that owner, so nothing
+ * batches two wallets into one transaction, and the deduped leg amounts reconcile exactly against
+ * the account's own router transfers. `conditionalEventStakeholderIsForeign` covers the case that
+ * invariant does not — a third party calling the CTF directly in the same transaction — but it
+ * cannot separate two wallets that both went through the router, since the CTF books the router as
+ * the stakeholder for both. A relayer that ever drove two wallets in one transaction would need
+ * ownership resolved per leg, against the parties of that transaction's collateral transfers.
  */
 export async function fetchAccountConditionalTransactions(
   account: Address,

--- a/web/netlify/functions/utils/transactions/fetchAccountConditionalEvents.ts
+++ b/web/netlify/functions/utils/transactions/fetchAccountConditionalEvents.ts
@@ -10,10 +10,11 @@ import {
 /**
  * CTF rows (split / merge / redeem) for one wallet, the history counterpart of the DEX source.
  *
- * Ownership is the union the P/L compute already uses, not `accountId` alone. `accountId` is not the
- * economic owner: a TradeExecutor driven by a relayer has its events booked to whichever EOA signed,
- * so the wallet's own splits and redeems never matched the filter and the History tab showed swaps
- * only — while the same legs counted in the P/L behind the header. Without a primary collateral
+ * Ownership is the union the P/L compute already uses, not `accountId` alone. `accountId` is not
+ * always the economic owner: rows indexed before `seer-indexer` `0261506` book a TradeExecutor
+ * driven by a session key to the key that signed, so the wallet's own splits and redeems never
+ * matched the filter and the History tab showed swaps only — while the same legs counted in the P/L
+ * behind the header. Without a primary collateral
  * there is no router transfer to follow, so that chain falls back to the narrow read rather than
  * losing its rows.
  *
@@ -28,9 +29,10 @@ import {
  * Reading a router transaction whole is correct because one router transaction carries one wallet's
  * operation. That does not rest on who signs it — a DeepFunding TradeExecutor accepts calls from a
  * temporary session key as well as its owner (`setTemporaryPermission`), and the key is what the
- * indexer books as `accountId`. It rests on the executor's `owner` being immutable, `batchExecute`
- * acting only for that owner whoever calls it, and an EOA transaction targeting one executor; the
- * deduped leg amounts reconcile exactly against the account's own router transfers.
+ * indexer booked as `accountId` before `seer-indexer` `0261506`. It rests on the executor's `owner`
+ * being immutable, `batchExecute` acting only for that owner whoever calls it, and an EOA
+ * transaction targeting one executor; the deduped leg amounts reconcile exactly against the
+ * account's own router transfers.
  * `conditionalEventStakeholderIsForeign` covers the case that does not — a third party calling the
  * CTF directly in the same transaction — but it cannot separate two wallets that both went through
  * the router, since the CTF books the router as the stakeholder for both. The one way to get there

--- a/web/src/components/Market/Header/MarketHeader.tsx
+++ b/web/src/components/Market/Header/MarketHeader.tsx
@@ -67,11 +67,15 @@ function MarketPnL({
   const { data: marketPnL, isLoading } = usePortfolioPnL(account, chainId, "all", marketId);
   if (!account) return null;
 
+  // A failed compute still answers 200 with zeros, so `marketPnL` alone does not mean there is a
+  // number to show. `computed` is what separates a real 0 from one that stands in for nothing.
+  const measured = marketPnL && marketPnL.computed !== false ? marketPnL : undefined;
+
   return (
     <span className="ml-3 flex items-center gap-1">
       <span className="text-base-content/70 @[510px]:inline-block hidden">{"P&L:"}</span>
-      <span className="ml-1">{isLoading ? <Spinner /> : marketPnL ? formatBigNumbers(marketPnL.pnl) : "N/A"}</span>
-      {!isLoading && marketPnL && <USDIcon />}
+      <span className="ml-1">{isLoading ? <Spinner /> : measured ? formatBigNumbers(measured.pnl) : "N/A"}</span>
+      {!isLoading && measured && <USDIcon />}
     </span>
   );
 }

--- a/web/src/pages/portfolio/+Page.tsx
+++ b/web/src/pages/portfolio/+Page.tsx
@@ -115,6 +115,10 @@ function PortfolioPnLHistory({
 }) {
   const { data: plData, isLoading, error, refetch, isFetching } = usePortfolioPnL(account, chainId, period);
   const pnl = plData?.pnl ?? 0;
+  // The global P/L is a table read, and a miss returns zeros. Showing those as "$0.00" states a
+  // result the refresh job never produced — indistinguishable, to the reader, from a wallet that
+  // genuinely broke even after hundreds of trades.
+  const notComputed = plData?.computed === false;
   const tone = signedTone(pnl);
   const periodMeta = PNL_PERIODS.find((p) => p.id === period) ?? PNL_PERIODS.find((p) => p.id === "all")!;
 
@@ -155,11 +159,20 @@ function PortfolioPnLHistory({
               {isFetching ? "Retrying…" : "Try again"}
             </button>
           </div>
+        ) : notComputed ? (
+          <p
+            className="text-2xl font-semibold text-black-secondary"
+            title="This wallet has not been included in a P&L refresh yet."
+          >
+            &mdash;
+          </p>
         ) : (
           <p className={`text-2xl font-semibold ${SIGNED_TONE_CLASS[tone]}`}>{formatUsd(pnl, { signed: true })}</p>
         )}
       </div>
-      <p className="text-sm text-black-primary">{periodMeta.hint}</p>
+      <p className="text-sm text-black-primary">
+        {notComputed ? "Not computed for this wallet yet." : periodMeta.hint}
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
A portfolio whose CTF operations go through a TradeExecutor driven by a relayer showed swaps only. The wallet behind this had 3,912 rows in `get-transactions`, every one a swap, while 15 router transactions of its own moved 1,561 sUSDS out and 1,563 back in.

`ConditionalEvent.accountId` is not the economic owner. When the CTF stakeholder is the router the indexer rewrites it to `transaction.from`, which is right when the user signs, but a relayer-driven executor has the event booked to whichever EOA happened to sign while the collateral leaves the executor. All 22 events in those 15 transactions were booked to two relayer EOAs, so an `accountId` filter returned none of them. The P/L compute already corrects this by widening ownership to the transactions where primary collateral actually moved; `get-transactions` did not, so a leg counted in the header P/L was invisible in the history below it.

The union moves out of `portfolioPlCompute` into
`fetchConditionalEventsForAccountWidened`, and the scoped P/L helper delegates to it and reapplies its market filter, so ownership has one definition. Its two halves are independent and now run together.

The history source collapses the indexer's market fan-out before rendering, which the endpoint cannot do for itself: `transactionKey` dedupes by `eventId` and the duplicate legs carry distinct ids, so one redeem would render up to five times. For this wallet the 22 raw rows are 17 real legs (7 split, 2 merge, 8 redeem), and the deduped amounts reconcile exactly against the router transfers -- 1,561.40 sUSDS of splits against 1,561.3956 out, 1,563.65 of merges and redeems against 1,563.6471 in -- which is the check that the economic leg is attributed once. `preferMarketIds` is the wallet's own market universe, matching what `marketPeriodBuckets` passes, so a fanned-out leg lands on the same market in both views.

A rejected event source now degrades the wallet instead of being swallowed. It never reached `failures`, so a partial payload was cached for the full TTL, and the widened path queries far more of the indexer than the single `accountId` call it replaces -- an outage would have frozen exactly the swaps-only view this change exists to remove. The cache key goes to `:v3` for the same reason blobs are versioned elsewhere.

Reading a router transaction whole assumes it carries one user's operation. That assumption was already load-bearing for P/L; it is now documented where it drives user-visible rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction and portfolio history accuracy for router-managed collateral movements.
  - Added support for relayer-booked split, merge, and redeem activity.
  - Removed duplicate transaction entries discovered through multiple sources.
  - Prevented incomplete transaction results from being cached.
  - Expanded portfolio leaderboard coverage for wallets identified through account activity.
  - Improved filtering to exclude activity incorrectly attributed to another wallet.
- **User Experience**
  - Portfolio P/L now displays “N/A,” an em dash, or “Not computed” when results are unavailable instead of showing misleading zero values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->