### PR TITLE
Find leaderboard candidates that only ever swapped against a pool

### DIFF
--- a/web/netlify/functions/compare-pnl-market-background.ts
+++ b/web/netlify/functions/compare-pnl-market-background.ts
@@ -77,6 +77,9 @@ export default async (req: Request) => {
       : (
           await listLeaderboardCandidates(supabase, chainId, undefined, {
             cutoffDay: recentOnly ? undefined : 0,
+            // A coverage comparison wants the whole population, not the slice discovered since the
+            // last refresh, so it pays for the full indexer scans instead of resuming a watermark.
+            incremental: false,
           })
         )
           .map((c) => c.address)

--- a/web/netlify/functions/compare-pnl-market-background.ts
+++ b/web/netlify/functions/compare-pnl-market-background.ts
@@ -63,6 +63,11 @@ export default async (req: Request) => {
   const comparisons: WalletComparison[] = [];
   const failures: Array<{ account: string; chainId: number; error: string }> = [];
   let abortedByBudget = false;
+  // A candidate scan that stopped at its page cap means the population below is the oldest slice of
+  // the chain's history rather than the whole of it. That is not a wrong comparison, but it is a
+  // partial one, and a coverage report that cannot say so invites reading "no residuals" as "no
+  // gaps" — see `listLeaderboardCandidates`.
+  const truncatedScans = new Set<string>();
 
   for (const chainId of chains) {
     if (Date.now() >= deadlineMs) {
@@ -80,6 +85,7 @@ export default async (req: Request) => {
             // A coverage comparison wants the whole population, not the slice discovered since the
             // last refresh, so it pays for the full indexer scans instead of resuming a watermark.
             incremental: false,
+            onScanTruncated: (source) => truncatedScans.add(`${chainId}:${source}`),
           })
         )
           .map((c) => c.address)
@@ -137,6 +143,7 @@ export default async (req: Request) => {
       {
         elapsedMs: Date.now() - startedAt,
         abortedByBudget,
+        truncatedScans: [...truncatedScans],
         failures: failures.length,
         ...summary,
       },
@@ -148,7 +155,14 @@ export default async (req: Request) => {
     console.error("compare-pnl-market: wallets that failed to compute", JSON.stringify(failures.slice(0, 20), null, 2));
   }
 
-  return new Response(JSON.stringify({ ...summary, failures: failures.length, abortedByBudget }, null, 2), {
-    headers: { "Content-Type": "application/json" },
-  });
+  return new Response(
+    JSON.stringify(
+      { ...summary, failures: failures.length, abortedByBudget, truncatedScans: [...truncatedScans] },
+      null,
+      2,
+    ),
+    {
+      headers: { "Content-Type": "application/json" },
+    },
+  );
 };

--- a/web/netlify/functions/get-pnl-leaderboard.mts
+++ b/web/netlify/functions/get-pnl-leaderboard.mts
@@ -170,8 +170,8 @@ async function loadMaterializedRows(args: {
       .eq("period", args.period)
       // Rows zero in every column contribute nothing to any merge and are dropped after the rollup
       // anyway (`hasLeaderboardActivity`); not loading them is most of this query, because the
-      // refresh writes one row per (wallet, scope, period) for every address with any indexed
-      // transaction on the chain. Wider than that filter on purpose: this runs on *materialized*
+      // refresh writes one row per (wallet, scope, period) for every candidate it computes, whether
+      // or not that wallet turned out to have traded. Wider than that filter on purpose: this runs on *materialized*
       // rows, where a TradeExecutor group splits its numbers across members, so `scored_capital_usd`
       // keeps the owner row of a group that traded only conditional markets — `market_count` and the
       // additive totals are zero there while the score statistics are not.

--- a/web/netlify/functions/refresh-pnl-leaderboard-background.ts
+++ b/web/netlify/functions/refresh-pnl-leaderboard-background.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
 import { requireBackgroundSecret } from "./utils/backgroundAuth";
+import { resetCandidateScanWatermark } from "./utils/leaderboardCandidateWatermark";
 import {
   PNL_LEADERBOARD_REFRESH_BUDGET_MS,
   listPnlLeaderboardRefreshJobs,
@@ -26,8 +27,9 @@ const supabase = createClient<Database>(process.env.SUPABASE_PROJECT_URL!, proce
  * schedule can continue the (app, chain) ring from a persisted cursor.
  *
  * Overrides: `?appId`, `?chainId`, `?batchSize`, `?accounts=0x..,0x..` (recompute exactly these),
- * and `?ownerGroups=1` (walk the TradeExecutor owner map instead of the analytics candidates — the
- * backfill for owner-grouped score statistics). None of them move the shared ring cursor.
+ * `?ownerGroups=1` (walk the TradeExecutor owner map instead of the analytics candidates — the
+ * backfill for owner-grouped score statistics), and `?rescanCandidates=1` (rewind the indexer
+ * candidate scans to the start of history). None of them move the shared ring cursor.
  */
 export default async (req: Request) => {
   if (process.env.DISABLE_SCHEDULED_FUNCTIONS === "true") {
@@ -73,6 +75,12 @@ export default async (req: Request) => {
     });
   }
 
+  // `?rescanCandidates=1` rewinds the per-chain watermark the indexer candidate scans resume from,
+  // so the next runs walk the whole history again. Needed after a reindex, or after widening what
+  // counts as a candidate — the scans are incremental, so a new rule would otherwise only ever be
+  // applied to transfers that had not happened yet.
+  const rescanCandidates = url.searchParams.get("rescanCandidates") === "1";
+
   const jobs = listPnlLeaderboardRefreshJobs().filter(
     (job) =>
       (onlyAppId ? job.appId === onlyAppId : true) &&
@@ -91,9 +99,16 @@ export default async (req: Request) => {
 
   // A filtered run must not move the shared ring cursor, or it would skip whatever the scheduled
   // run was about to pick up next.
-  const filtered = onlyAppId != null || onlyChainId != null || explicitAccounts.length > 0 || ownerGroups;
+  const filtered =
+    onlyAppId != null || onlyChainId != null || explicitAccounts.length > 0 || ownerGroups || rescanCandidates;
   const cursor = filtered ? null : await loadPnlLeaderboardRefreshCursor(supabase);
   const startIndex = nextJobIndexAfterCursor(jobs, cursor);
+
+  if (rescanCandidates) {
+    const chainIds = [...new Set(jobs.map((job) => job.chainId))];
+    await Promise.all(chainIds.map((id) => resetCandidateScanWatermark(supabase, id)));
+    console.log(`refresh-pnl-leaderboard-background: candidate scan watermark reset for chains ${chainIds.join(",")}`);
+  }
 
   const startedAt = Date.now();
   const deadlineMs = startedAt + PNL_LEADERBOARD_REFRESH_BUDGET_MS;

--- a/web/netlify/functions/utils/leaderboardCandidateSources.test.ts
+++ b/web/netlify/functions/utils/leaderboardCandidateSources.test.ts
@@ -14,6 +14,12 @@ vi.mock("./envioClient", () => ({
   seerEnvioSdk: () => ({ GetTransfers }),
 }));
 
+const chainPoolAddressSet = vi.fn();
+
+vi.mock("./leaderboardPools", () => ({
+  chainPoolAddressSet: (...args: unknown[]) => chainPoolAddressSet(...args),
+}));
+
 import { listLeaderboardCandidates } from "./pnlLeaderboard";
 
 const CHAIN = 10 as const;
@@ -28,55 +34,123 @@ const RELAYER = "0x4d684bbc7296a913f95257b7d5659047031f65e6";
 /** The deployed optimism router — the scan drops it through `getRouterAddresses(10)`. */
 const ROUTER = "0x179d8f8c811b8c759c33809dbc6c5cedc62d05dd";
 const PRIMARY = "0xb5b2dc7fd34c249f4be7fb1fcea07950784229e0";
+/** An outcome-token pool. Its P/L would be its inventory, so it must never be a candidate. */
+const POOL = "0x1111111111111111111111111111111111111111";
+const POOL2 = "0x2222222222222222222222222222222222222222";
+/** A wallet with no relationship to any pool — an airdrop counterparty. */
+const OUTSIDER = "0x3333333333333333333333333333333333333333";
+const ZERO = "0x0000000000000000000000000000000000000000";
 
-/** Minimal `supabase.from(...).select(...)…range()` chain: analytics returns `rows` once. */
-function supabaseReturning(rows: { address: string; day: number }[]) {
-  const builder: Record<string, unknown> = {};
-  for (const method of ["select", "eq", "in", "gte", "order"]) {
-    builder[method] = () => builder;
-  }
-  builder.range = (from: number) => Promise.resolve({ data: from === 0 ? rows : [], error: null });
-  // biome-ignore lint/suspicious/noExplicitAny: hand-rolled stand-in for the query builder
-  return { from: () => builder } as any;
-}
+const POOLS = new Set([POOL, POOL2]);
 
-/** A primary-collateral leg between `wallet` and the router, as the indexer books it. */
-function routerCollateralRow(wallet: string, timestamp: number, toRouter = true) {
+type TransferRow = ReturnType<typeof transferRow>;
+
+function transferRow(kind: string, from: string, to: string, timestamp: number) {
   return {
     chainId: String(CHAIN),
-    from: toRouter ? wallet : ROUTER,
-    to: toRouter ? ROUTER : wallet,
+    from,
+    to,
     timestamp: String(timestamp),
     blockNumber: "1",
     transactionHash: "0xabc",
     transactionFrom: RELAYER,
     logIndex: "1",
     value: "1000",
-    kind: "router_collateral",
-    involvesRouter: true,
+    kind,
+    involvesRouter: kind === "router_collateral",
     market: null,
     token: { id: PRIMARY },
   };
 }
 
+/** A primary-collateral leg between `wallet` and the router, as the indexer books it. */
+function routerCollateralRow(wallet: string, timestamp: number, toRouter = true) {
+  return toRouter
+    ? transferRow("router_collateral", wallet, ROUTER, timestamp)
+    : transferRow("router_collateral", ROUTER, wallet, timestamp);
+}
+
+/** An outcome-token leg of a swap: the pool on one side, whoever traded on the other. */
+function outcomeRow(from: string, to: string, timestamp: number) {
+  return transferRow("outcome", from, to, timestamp);
+}
+
+/**
+ * Answer `GetTransfers` per `kind`, since the protocol-wide path now runs two scans. A kind with no
+ * entry returns nothing, which is how a chain with no such transfers behaves.
+ */
+function transfersByKind(byKind: Partial<Record<"router_collateral" | "outcome", TransferRow[]>>) {
+  GetTransfers.mockImplementation((args: { where: { kind: { _eq: string } } }) =>
+    Promise.resolve({ Transfer: byKind[args.where.kind._eq as keyof typeof byKind] ?? [] }),
+  );
+}
+
+type StubOptions = {
+  analytics?: { address: string; day: number }[];
+  materialized?: string[];
+  watermark?: { routerCollateralTs: number; outcomeTradeTs: number } | null;
+};
+
+/** Records what the run persisted, so the watermark assertions can read it back. */
+// biome-ignore lint/suspicious/noExplicitAny: hand-rolled stand-in for the Supabase client
+type Stub = { client: any; written: () => unknown };
+
+/**
+ * Minimal table-aware `supabase.from(...)` stand-in: the analytics and materialized halves page
+ * through `range`, and the watermark round-trips through `key_value`.
+ */
+function supabaseStub(options: StubOptions = {}): Stub {
+  let written: unknown;
+
+  const client = {
+    from(table: string) {
+      const builder: Record<string, unknown> = {};
+      for (const method of ["select", "eq", "in", "gte", "order"]) {
+        builder[method] = () => builder;
+      }
+      builder.range = (from: number) => {
+        if (from !== 0) return Promise.resolve({ data: [], error: null });
+        if (table === "analytics_daily_wallet" || table === "analytics_daily_wallet_market") {
+          return Promise.resolve({ data: options.analytics ?? [], error: null });
+        }
+        if (table === "pnl_leaderboard") {
+          return Promise.resolve({ data: (options.materialized ?? []).map((address) => ({ address })), error: null });
+        }
+        return Promise.resolve({ data: [], error: null });
+      };
+      builder.maybeSingle = () =>
+        Promise.resolve({ data: options.watermark ? { value: options.watermark } : null, error: null });
+      builder.upsert = (row: { value: unknown }) => {
+        written = row.value;
+        return Promise.resolve({ error: null });
+      };
+      return builder;
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: hand-rolled stand-in for the query builder
+  } as any;
+
+  return { client, written: () => written };
+}
+
+function addressesOf(candidates: { address: string }[]): string[] {
+  return candidates.map((candidate) => candidate.address);
+}
+
 beforeEach(() => {
   GetTransfers.mockReset();
+  GetTransfers.mockResolvedValue({ Transfer: [] });
+  chainPoolAddressSet.mockReset();
+  chainPoolAddressSet.mockResolvedValue(POOLS);
 });
 
 describe("listLeaderboardCandidates", () => {
   it("reaches a wallet that only ever traded through a relayer-driven executor", async () => {
-    GetTransfers.mockResolvedValueOnce({ Transfer: [routerCollateralRow(EXECUTOR, 10 * DAY + 500)] });
+    transfersByKind({ router_collateral: [routerCollateralRow(EXECUTOR, 10 * DAY + 500)] });
 
-    const candidates = await listLeaderboardCandidates(
-      supabaseReturning([{ address: RELAYER, day: 9 * DAY }]),
-      CHAIN,
-      undefined,
-      {
-        cutoffDay: 0,
-      },
-    );
+    const stub = supabaseStub({ analytics: [{ address: RELAYER, day: 9 * DAY }] });
+    const candidates = await listLeaderboardCandidates(stub.client, CHAIN, undefined, { cutoffDay: 0 });
 
-    const addresses = candidates.map((c) => c.address);
+    const addresses = addressesOf(candidates);
     // The executor is the whole point: analytics only ever saw the relayer that signed for it.
     expect(addresses).toContain(EXECUTOR);
     expect(addresses).toContain(RELAYER);
@@ -85,74 +159,165 @@ describe("listLeaderboardCandidates", () => {
     expect(candidates.find((c) => c.address === EXECUTOR)?.lastActivityDay).toBe(10 * DAY);
   });
 
-  it("keeps the latest activity day when both sources name the same wallet", async () => {
-    GetTransfers.mockResolvedValueOnce({ Transfer: [routerCollateralRow(RELAYER, 12 * DAY, false)] });
+  it("reaches a wallet that only ever swapped against a pool", async () => {
+    // Never a router leg, and `tx_from` is the session key: this wallet is invisible to both of the
+    // other sources, and is exactly the executor that only buys and sells outcome tokens.
+    transfersByKind({ outcome: [outcomeRow(POOL, EXECUTOR, 11 * DAY + 10)] });
 
-    const candidates = await listLeaderboardCandidates(
-      supabaseReturning([{ address: RELAYER, day: 9 * DAY }]),
-      CHAIN,
-      undefined,
-      {
-        cutoffDay: 0,
-      },
-    );
+    const stub = supabaseStub({ analytics: [{ address: RELAYER, day: 9 * DAY }] });
+    const candidates = await listLeaderboardCandidates(stub.client, CHAIN, undefined, { cutoffDay: 0 });
+
+    expect(addressesOf(candidates)).toContain(EXECUTOR);
+    expect(candidates.find((c) => c.address === EXECUTOR)?.lastActivityDay).toBe(11 * DAY);
+  });
+
+  it("never lists a pool, on either side of the transfer", async () => {
+    transfersByKind({
+      outcome: [outcomeRow(POOL, EXECUTOR, 11 * DAY), outcomeRow(EXECUTOR, POOL2, 11 * DAY + 1)],
+    });
+
+    const candidates = await listLeaderboardCandidates(supabaseStub().client, CHAIN, undefined, { cutoffDay: 0 });
+
+    expect(addressesOf(candidates)).toEqual([EXECUTOR]);
+  });
+
+  it("ignores transfers that do not touch a pool, and hops between two pools", async () => {
+    transfersByKind({
+      outcome: [
+        // An airdrop or an OTC transfer names nobody who traded.
+        outcomeRow(OUTSIDER, OWNER, 11 * DAY),
+        // A direct hop between pools would otherwise promote the unrecognized side.
+        outcomeRow(POOL, POOL2, 11 * DAY + 1),
+        outcomeRow(ZERO, POOL, 11 * DAY + 2),
+      ],
+    });
+
+    const candidates = await listLeaderboardCandidates(supabaseStub().client, CHAIN, undefined, { cutoffDay: 0 });
+
+    expect(candidates).toEqual([]);
+  });
+
+  it("does not scan outcome transfers at all when the pool set is empty", async () => {
+    // An empty set has to disable the scan, not open it: with no pool to recognize, every transfer
+    // would look like a trade against an unknown counterparty.
+    chainPoolAddressSet.mockResolvedValue(new Set());
+    transfersByKind({ outcome: [outcomeRow(POOL, EXECUTOR, 11 * DAY)] });
+
+    const candidates = await listLeaderboardCandidates(supabaseStub().client, CHAIN, undefined, { cutoffDay: 0 });
+
+    expect(candidates).toEqual([]);
+    expect(GetTransfers.mock.calls.map((call) => call[0].where.kind._eq)).toEqual(["router_collateral"]);
+  });
+
+  it("keeps the latest activity day when both sources name the same wallet", async () => {
+    transfersByKind({ router_collateral: [routerCollateralRow(RELAYER, 12 * DAY, false)] });
+
+    const stub = supabaseStub({ analytics: [{ address: RELAYER, day: 9 * DAY }] });
+    const candidates = await listLeaderboardCandidates(stub.client, CHAIN, undefined, { cutoffDay: 0 });
 
     expect(candidates).toHaveLength(1);
     expect(candidates[0].lastActivityDay).toBe(12 * DAY);
   });
 
-  it("still returns the analytics half when the indexer scan fails", async () => {
-    GetTransfers.mockRejectedValueOnce(new Error("indexer down"));
+  it("keeps refreshing wallets that already have a row", async () => {
+    // The indexer scans are incremental, so a wallet they found on an earlier run is not in this
+    // run's slice. Without the materialized half its row would freeze at the price of that day.
+    const stub = supabaseStub({ materialized: [EXECUTOR] });
+    const candidates = await listLeaderboardCandidates(stub.client, CHAIN, undefined, { cutoffDay: 0 });
 
+    expect(candidates).toEqual([{ address: EXECUTOR, lastActivityDay: 0 }]);
+  });
+
+  it("still returns the other sources when the indexer scans fail", async () => {
+    GetTransfers.mockRejectedValue(new Error("indexer down"));
+
+    const stub = supabaseStub({ analytics: [{ address: RELAYER, day: 9 * DAY }] });
+    const candidates = await listLeaderboardCandidates(stub.client, CHAIN, undefined, { cutoffDay: 0 });
+
+    // Degrading to the old coverage beats blanking a board the analytics half could refresh.
+    expect(addressesOf(candidates)).toEqual([RELAYER]);
+  });
+
+  it("asks the indexer for router collateral and pool trades only, never for every token holder", async () => {
+    // The holder view (`AccountActivity`) would hand back every Uniswap pool on the chain, and a
+    // pool's P/L is its inventory. Moving collateral with the router, or outcome tokens against a
+    // pool, is what a pool never does.
+    await listLeaderboardCandidates(supabaseStub().client, CHAIN, undefined, { cutoffDay: 3 * DAY });
+
+    expect(GetTransfers).toHaveBeenCalledTimes(2);
+    const wheres = GetTransfers.mock.calls.map((call) => call[0].where);
+    expect(wheres).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: { _eq: "router_collateral" }, timestamp: { _gte: String(3 * DAY) } }),
+        expect.objectContaining({ kind: { _eq: "outcome" }, timestamp: { _gte: String(3 * DAY) } }),
+      ]),
+    );
+  });
+
+  it("never lists the router itself or the zero address as a candidate", async () => {
+    transfersByKind({
+      router_collateral: [
+        routerCollateralRow(EXECUTOR, 10 * DAY),
+        transferRow("router_collateral", ZERO, ROUTER, 10 * DAY),
+      ],
+      outcome: [outcomeRow(POOL, ROUTER, 10 * DAY)],
+    });
+
+    const candidates = await listLeaderboardCandidates(supabaseStub().client, CHAIN, undefined, { cutoffDay: 0 });
+
+    expect(addressesOf(candidates)).toEqual([EXECUTOR]);
+  });
+
+  it("resumes each scan from its watermark and advances it to the last transfer read", async () => {
+    transfersByKind({
+      router_collateral: [routerCollateralRow(EXECUTOR, 20 * DAY + 7)],
+      outcome: [outcomeRow(POOL, EXECUTOR, 21 * DAY + 9)],
+    });
+
+    const stub = supabaseStub({ watermark: { routerCollateralTs: 5 * DAY, outcomeTradeTs: 6 * DAY } });
+    await listLeaderboardCandidates(stub.client, CHAIN, undefined, { cutoffDay: 0 });
+
+    const wheres = GetTransfers.mock.calls.map((call) => call[0].where);
+    expect(wheres).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ kind: { _eq: "router_collateral" }, timestamp: { _gte: String(5 * DAY) } }),
+        expect.objectContaining({ kind: { _eq: "outcome" }, timestamp: { _gte: String(6 * DAY) } }),
+      ]),
+    );
+    expect(stub.written()).toEqual({ routerCollateralTs: 20 * DAY + 7, outcomeTradeTs: 21 * DAY + 9 });
+  });
+
+  it("leaves the watermark alone when a scan fails, so the slice is read again", async () => {
+    GetTransfers.mockRejectedValue(new Error("indexer down"));
+
+    const stub = supabaseStub({ watermark: { routerCollateralTs: 5 * DAY, outcomeTradeTs: 6 * DAY } });
+    await listLeaderboardCandidates(stub.client, CHAIN, undefined, { cutoffDay: 0 });
+
+    expect(stub.written()).toBeUndefined();
+  });
+
+  it("scans from the given cutoff, ignoring the watermark, when not incremental", async () => {
+    const stub = supabaseStub({ watermark: { routerCollateralTs: 5 * DAY, outcomeTradeTs: 6 * DAY } });
+    await listLeaderboardCandidates(stub.client, CHAIN, undefined, { cutoffDay: 0, incremental: false });
+
+    for (const call of GetTransfers.mock.calls) {
+      expect(call[0].where.timestamp).toBeUndefined();
+    }
+    expect(stub.written()).toBeUndefined();
+  });
+
+  it("leaves market-scoped jobs on the analytics source alone", async () => {
+    const stub = supabaseStub({ analytics: [{ address: RELAYER, day: 9 * DAY }] });
     const candidates = await listLeaderboardCandidates(
-      supabaseReturning([{ address: RELAYER, day: 9 * DAY }]),
+      stub.client,
       CHAIN,
-      undefined,
+      ["0xaaaa000000000000000000000000000000000001"],
       {
         cutoffDay: 0,
       },
     );
 
-    // Degrading to the old coverage beats blanking a board the analytics half could refresh.
-    expect(candidates.map((c) => c.address)).toEqual([RELAYER]);
-  });
-
-  it("asks the indexer for router collateral only, never for every token holder", async () => {
-    // The holder view (`AccountActivity`) would hand back every Uniswap pool on the chain, and a
-    // pool's P/L is its inventory. Collateral moving with the router is what a pool never does.
-    GetTransfers.mockResolvedValueOnce({ Transfer: [] });
-
-    await listLeaderboardCandidates(supabaseReturning([]), CHAIN, undefined, { cutoffDay: 3 * DAY });
-
-    expect(GetTransfers).toHaveBeenCalledTimes(1);
-    expect(GetTransfers.mock.calls[0][0].where).toMatchObject({
-      kind: { _eq: "router_collateral" },
-      timestamp: { _gte: String(3 * DAY) },
-    });
-  });
-
-  it("never lists the router itself or the zero address as a candidate", async () => {
-    GetTransfers.mockResolvedValueOnce({
-      Transfer: [
-        routerCollateralRow(EXECUTOR, 10 * DAY),
-        { ...routerCollateralRow(EXECUTOR, 10 * DAY), from: "0x0000000000000000000000000000000000000000", to: ROUTER },
-      ],
-    });
-
-    const candidates = await listLeaderboardCandidates(supabaseReturning([]), CHAIN, undefined, { cutoffDay: 0 });
-
-    expect(candidates.map((c) => c.address)).toEqual([EXECUTOR]);
-  });
-
-  it("leaves market-scoped jobs on the analytics source alone", async () => {
-    const candidates = await listLeaderboardCandidates(
-      supabaseReturning([{ address: RELAYER, day: 9 * DAY }]),
-      CHAIN,
-      ["0xaaaa000000000000000000000000000000000001"],
-      { cutoffDay: 0 },
-    );
-
-    expect(candidates.map((c) => c.address)).toEqual([RELAYER]);
+    expect(addressesOf(candidates)).toEqual([RELAYER]);
     expect(GetTransfers).not.toHaveBeenCalled();
   });
 });

--- a/web/netlify/functions/utils/leaderboardCandidateSources.test.ts
+++ b/web/netlify/functions/utils/leaderboardCandidateSources.test.ts
@@ -24,6 +24,8 @@ import { listLeaderboardCandidates } from "./pnlLeaderboard";
 
 const CHAIN = 10 as const;
 const DAY = 86_400;
+/** Mirrors `PAGE` in `seerIndexerPortfolio`: a short page is what tells a scan the stream ended. */
+const PAGE = 1000;
 
 /** The owner EOA never signs its own trades, so the analytics rollups never name it. */
 const OWNER = "0x02dadbe42f385fa68f96c753df7f24c863701481";
@@ -304,6 +306,39 @@ describe("listLeaderboardCandidates", () => {
       expect(call[0].where.timestamp).toBeUndefined();
     }
     expect(stub.written()).toBeUndefined();
+  });
+
+  it("reports a scan that stopped at the page cap, so a coverage run knows its slice is partial", async () => {
+    // The stub ignores `offset`, so handing back a full page every time is a stream that never
+    // ends: the scan pages until the cap and stops. With `incremental: false` there is no watermark
+    // to carry the remainder, so this is the truncation the callback exists to surface.
+    const fullPage = Array.from({ length: PAGE }, (_, i) => routerCollateralRow(EXECUTOR, 10 * DAY + i));
+    transfersByKind({ router_collateral: fullPage });
+
+    const truncated: string[] = [];
+    await listLeaderboardCandidates(supabaseStub().client, CHAIN, undefined, {
+      cutoffDay: 0,
+      incremental: false,
+      onScanTruncated: (source) => truncated.push(source),
+    });
+
+    expect(truncated).toEqual(["router_collateral"]);
+  });
+
+  it("stays quiet when a scan reaches the end of the stream", async () => {
+    transfersByKind({
+      router_collateral: [routerCollateralRow(EXECUTOR, 10 * DAY)],
+      outcome: [outcomeRow(POOL, EXECUTOR, 11 * DAY)],
+    });
+
+    const truncated: string[] = [];
+    await listLeaderboardCandidates(supabaseStub().client, CHAIN, undefined, {
+      cutoffDay: 0,
+      incremental: false,
+      onScanTruncated: (source) => truncated.push(source),
+    });
+
+    expect(truncated).toEqual([]);
   });
 
   it("leaves market-scoped jobs on the analytics source alone", async () => {

--- a/web/netlify/functions/utils/leaderboardCandidateWatermark.ts
+++ b/web/netlify/functions/utils/leaderboardCandidateWatermark.ts
@@ -64,8 +64,16 @@ export async function readCandidateScanWatermark(
 }
 
 /**
- * Only ever moves forward. A scan that failed reports the watermark it started from, so a transient
- * indexer error re-reads that slice on the next run instead of skipping it.
+ * A scan that failed reports the watermark it started from, so a transient indexer error re-reads
+ * that slice on the next run instead of skipping it.
+ *
+ * Last writer wins, and the caller's forward-only check is against the value *it* read, so this is
+ * only monotonic while one run is in flight per chain. Two overlapping invocations (a manual
+ * trigger crossing the schedule) can land the slower one's lower watermark last, and a
+ * `?rescanCandidates=1` reset can be overwritten by a run that started before it. Both cost a
+ * re-scan of a slice, not correctness — candidates are a set and the scans are additive — so this
+ * stays an unsynchronized upsert rather than carrying a lock or a version column on `key_value`. If
+ * a rescan ever looks like it did not take, re-run it with no scheduled run in flight.
  */
 export async function writeCandidateScanWatermark(
   supabase: SupabaseClient<Database>,

--- a/web/netlify/functions/utils/leaderboardCandidateWatermark.ts
+++ b/web/netlify/functions/utils/leaderboardCandidateWatermark.ts
@@ -1,0 +1,91 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "./supabase";
+
+/**
+ * How far each indexer-side candidate scan has walked on a chain.
+ *
+ * Both scans page the indexer in `timestamp` order and stop at a page cap. Without a watermark that
+ * cap truncates silently, and always in the same place: the refresh asks for the whole history, so a
+ * chain past the cap would only ever hand back its *oldest* transfers and no recent wallet could
+ * become a candidate. Persisting the highest timestamp reached turns the cap into a resumable walk —
+ * each run continues where the last one stopped, and a chain whose history is longer than one run
+ * backfills over several of them without a separate backfill mode.
+ *
+ * Timestamps are unix seconds and the next scan re-reads from them inclusively. Overlapping a second
+ * is deliberate and harmless: candidates are a set.
+ */
+export type CandidateScanWatermark = {
+  routerCollateralTs: number;
+  outcomeTradeTs: number;
+};
+
+export const EMPTY_CANDIDATE_SCAN_WATERMARK: CandidateScanWatermark = {
+  routerCollateralTs: 0,
+  outcomeTradeTs: 0,
+};
+
+/** KV key in `key_value`. Format is stable (`…_${chainId}`); value is a `CandidateScanWatermark`. */
+export function candidateScanWatermarkKey(chainId: number): string {
+  return `seer_pnl_leaderboard_candidate_scan_${chainId}`;
+}
+
+function readTimestamp(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0;
+}
+
+function parseWatermark(value: unknown): CandidateScanWatermark {
+  if (!value || typeof value !== "object") return { ...EMPTY_CANDIDATE_SCAN_WATERMARK };
+  const record = value as Record<string, unknown>;
+  return {
+    routerCollateralTs: readTimestamp(record.routerCollateralTs),
+    outcomeTradeTs: readTimestamp(record.outcomeTradeTs),
+  };
+}
+
+/**
+ * Never throws: a missing or unreadable watermark degrades to "scan from the beginning", which is
+ * correct but slower, and is the same thing a fresh chain does.
+ */
+export async function readCandidateScanWatermark(
+  supabase: SupabaseClient<Database>,
+  chainId: number,
+): Promise<CandidateScanWatermark> {
+  const { data, error } = await supabase
+    .from("key_value")
+    .select("value")
+    .eq("key", candidateScanWatermarkKey(chainId))
+    .maybeSingle();
+
+  if (error) {
+    console.warn("pnl-leaderboard: candidate scan watermark unreadable", { chainId, error });
+    return { ...EMPTY_CANDIDATE_SCAN_WATERMARK };
+  }
+  return parseWatermark(data?.value ?? null);
+}
+
+/**
+ * Only ever moves forward. A scan that failed reports the watermark it started from, so a transient
+ * indexer error re-reads that slice on the next run instead of skipping it.
+ */
+export async function writeCandidateScanWatermark(
+  supabase: SupabaseClient<Database>,
+  chainId: number,
+  next: CandidateScanWatermark,
+): Promise<void> {
+  const { error } = await supabase.from("key_value").upsert(
+    {
+      key: candidateScanWatermarkKey(chainId),
+      value: next as unknown as Database["public"]["Tables"]["key_value"]["Insert"]["value"],
+    },
+    { onConflict: "key" },
+  );
+  if (error) {
+    // Losing the write costs a re-scan of one slice, not correctness.
+    console.warn("pnl-leaderboard: candidate scan watermark not persisted", { chainId, error });
+  }
+}
+
+/** Escape hatch behind `?rescanCandidates=1`: walk the whole history again from zero. */
+export async function resetCandidateScanWatermark(supabase: SupabaseClient<Database>, chainId: number): Promise<void> {
+  await writeCandidateScanWatermark(supabase, chainId, { ...EMPTY_CANDIDATE_SCAN_WATERMARK });
+}

--- a/web/netlify/functions/utils/leaderboardPools.ts
+++ b/web/netlify/functions/utils/leaderboardPools.ts
@@ -1,0 +1,86 @@
+import type { SupportedChain } from "@seer-pm/sdk";
+import { getMarketPoolsPairs } from "@seer-pm/sdk/market-pools";
+import type { Market } from "@seer-pm/sdk/market-types";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { fetchPools } from "./fetchPools";
+import { type LegacySubgraphMarket, MARKET_DB_FIELDS, mapGraphMarketFromDbResult } from "./markets";
+import type { Database } from "./supabase";
+import { type TtlCacheEntry, evictExpiredAndOldest } from "./ttlCache";
+
+const POOLS_CACHE_TTL_MS = 15 * 60 * 1000;
+const POOLS_CACHE_MAX_SIZE = 8;
+const MARKET_PAGE_SIZE = 1000;
+
+const poolsCache = new Map<string, TtlCacheEntry<Set<string>>>();
+
+async function loadMarketsForChain(supabase: SupabaseClient<Database>, chainId: number): Promise<Market[]> {
+  const markets: Market[] = [];
+  for (let from = 0; ; from += MARKET_PAGE_SIZE) {
+    const { data, error } = await supabase
+      .from("markets")
+      .select(MARKET_DB_FIELDS)
+      .eq("chain_id", chainId)
+      .not("subgraph_data", "is", null)
+      .order("id", { ascending: true })
+      .range(from, from + MARKET_PAGE_SIZE - 1);
+
+    if (error) throw new Error(`markets unavailable: ${error.message}`);
+    const rows = data ?? [];
+    for (const row of rows) {
+      try {
+        markets.push(mapGraphMarketFromDbResult(row.subgraph_data as LegacySubgraphMarket, row));
+      } catch {
+        // A malformed row costs one market's pools, not the whole exclusion set.
+      }
+    }
+    if (rows.length < MARKET_PAGE_SIZE) break;
+  }
+  return markets;
+}
+
+/**
+ * Every AMM pool on `chainId` that quotes a Seer outcome token, lowercased.
+ *
+ * This is the exclusion set the outcome-token candidate scan is built on, so its failure mode is
+ * what matters. `fetchOutcomeTokenPoolCounterparties` only accepts a wallet when the *other* side of
+ * its transfer is in this set, which means a pool missing from the set costs a candidate and can
+ * never turn a pool into one. An empty set therefore disables the scan rather than opening it, and
+ * that is the behaviour we want when the subgraph is down.
+ *
+ * Derived from the chain's markets rather than from bytecode probing, the same way
+ * `getLiquidityHolders` derives it (`marketLiquidityHolders.ts`): `getMarketPoolsPairs` gives the
+ * (outcome, collateral) pairs of every market and `fetchPools` asks the DEX subgraph which of them
+ * are deployed. Cached for 15 minutes because the refresh job walks a whole chain per invocation.
+ */
+export function chainPoolAddressSet(supabase: SupabaseClient<Database>, chainId: SupportedChain): Promise<Set<string>> {
+  const key = String(chainId);
+  const now = Date.now();
+  const existing = poolsCache.get(key);
+  if (existing && existing.expiresAt > now) return existing.promise;
+  poolsCache.delete(key);
+  evictExpiredAndOldest(poolsCache, now, POOLS_CACHE_MAX_SIZE);
+
+  const promise = loadChainPoolAddresses(supabase, chainId).catch((error) => {
+    poolsCache.delete(key);
+    throw error;
+  });
+  poolsCache.set(key, { promise, expiresAt: now + POOLS_CACHE_TTL_MS });
+  return promise;
+}
+
+async function loadChainPoolAddresses(
+  supabase: SupabaseClient<Database>,
+  chainId: SupportedChain,
+): Promise<Set<string>> {
+  const markets = await loadMarketsForChain(supabase, chainId);
+  const pairs = markets.flatMap((market) => getMarketPoolsPairs(market));
+  if (pairs.length === 0) return new Set();
+
+  const pools = await fetchPools(chainId, pairs);
+  return new Set(pools.map((pool) => pool.id.toLowerCase()));
+}
+
+/** Test seam: the 15-minute memo would otherwise leak one case's pools into the next. */
+export function clearChainPoolAddressCache(): void {
+  poolsCache.clear();
+}

--- a/web/netlify/functions/utils/pnlLeaderboard.ts
+++ b/web/netlify/functions/utils/pnlLeaderboard.ts
@@ -110,7 +110,10 @@ export function recentActivityCutoffDay(
  * run. `kind=outcome` is a far larger stream than `router_collateral`, and both scans stop at a page
  * cap; persisting how far they got turns that cap from a silent truncation into a walk that reaches
  * the head over successive runs. Pass `incremental: false` to scan from `cutoffDay` regardless —
- * what a coverage comparison wants, and what it pays for.
+ * what a coverage comparison wants, and what it pays for. The page cap still applies, and without a
+ * watermark there is no next run to carry the rest: a chain whose history is longer than one scan
+ * hands back only its oldest slice, every time. `onScanTruncated` reports exactly that, so a caller
+ * measuring coverage can say its population was partial instead of quietly treating it as whole.
  *
  * Market-scoped jobs keep the analytics-only path: the indexer view has no market dimension to
  * filter on, and widening those boards is not what this fixes.
@@ -129,6 +132,14 @@ export async function listLeaderboardCandidates(
     cutoffDay?: number;
     /** Resume the indexer scans from the persisted watermark, and advance it. Defaults to `true`. */
     incremental?: boolean;
+    /**
+     * Called once per indexer scan that stopped at the page cap, with its source name.
+     *
+     * An incremental scan treats the cap as a pause — it persists how far it got and the next run
+     * continues there — so it is the `incremental: false` callers that need this: they have no
+     * watermark to resume from, so whatever the cap cut off is simply never read.
+     */
+    onScanTruncated?: (source: string) => void;
   },
 ): Promise<LeaderboardCandidate[]> {
   const cutoffDay = opts?.cutoffDay ?? recentActivityCutoffDay();
@@ -156,6 +167,7 @@ export async function listLeaderboardCandidates(
           scanned.routerCollateralTs = ts;
         },
         { chainId, source: "router_collateral" },
+        opts?.onScanTruncated,
       ),
       listCandidatesFromScan(
         async () =>
@@ -168,6 +180,7 @@ export async function listLeaderboardCandidates(
           scanned.outcomeTradeTs = ts;
         },
         { chainId, source: "outcome_pool" },
+        opts?.onScanTruncated,
       ),
     ]);
 
@@ -206,11 +219,15 @@ function mergeCandidates(...lists: LeaderboardCandidate[][]): LeaderboardCandida
  *
  * `onScanned` is only called on success: a scan that threw must not advance a watermark, or the
  * slice it failed on is skipped forever.
+ *
+ * `onTruncated` fires when the scan stopped at its page cap rather than at the end of the stream,
+ * so a caller that is measuring coverage can tell a partial population from a whole one.
  */
 async function listCandidatesFromScan(
   scan: () => Promise<CandidateScanResult>,
   onScanned: (maxTimestamp: number) => void,
   context: { chainId: number; source: string },
+  onTruncated?: (source: string) => void,
 ): Promise<LeaderboardCandidate[]> {
   let result: CandidateScanResult;
   try {
@@ -220,6 +237,7 @@ async function listCandidatesFromScan(
     return [];
   }
   if (result.maxTimestamp > 0) onScanned(result.maxTimestamp);
+  if (result.reachedPageCap) onTruncated?.(context.source);
   return result.counterparties.map((row) => ({
     address: row.account,
     lastActivityDay: floorUtcDay(row.lastTransferTimestamp),

--- a/web/netlify/functions/utils/pnlLeaderboard.ts
+++ b/web/netlify/functions/utils/pnlLeaderboard.ts
@@ -7,6 +7,12 @@ import type { Address } from "viem";
 import { getDexScreenerPriceUSD } from "./common";
 import { jobUsesTradeExecutors, readOwnerMap, resolveOwnerMap } from "./executorOwners";
 import { expandMarketIdsWithChildren } from "./expandMarketsCache";
+import {
+  type CandidateScanWatermark,
+  readCandidateScanWatermark,
+  writeCandidateScanWatermark,
+} from "./leaderboardCandidateWatermark";
+import { chainPoolAddressSet } from "./leaderboardPools";
 import { fetchMarketFamilyRoots } from "./marketFamilies";
 import type { MarketPeriodBucket } from "./marketPeriodBuckets";
 import { computeRoiUsd } from "./pnlLeaderboardMetrics";
@@ -25,7 +31,13 @@ import {
   deriveOwnerGroupRows,
 } from "./pnlMarketRows";
 import { PORTFOLIO_PL_PERIODS, computePortfolioPlAllPeriods } from "./portfolioPlCompute";
-import { type PortfolioPlPeriod, fetchRouterCollateralCounterparties, floorUtcDay } from "./seerIndexerPortfolio";
+import {
+  type CandidateScanResult,
+  type PortfolioPlPeriod,
+  fetchOutcomeTokenPoolCounterparties,
+  fetchRouterCollateralCounterparties,
+  floorUtcDay,
+} from "./seerIndexerPortfolio";
 import type { Database, TablesInsert } from "./supabase";
 import type { OwnerMap } from "./tradeExecutorOwnersCore";
 
@@ -73,8 +85,8 @@ export function recentActivityCutoffDay(
  * Every wallet with analytics activity in the last `PNL_LEADERBOARD_RECENT_DAYS` UTC days.
  * When `marketIds` is omitted, uses the whole chain (All / protocol-wide).
  *
- * The protocol-wide list is the union of two sources that see different things, and the P/L job
- * needs both:
+ * The protocol-wide list is the union of four sources that see different things, and the P/L job
+ * needs all of them:
  *
  * - **Supabase analytics** (`analytics_daily_wallet`) is keyed by `tokens_transfers.tx_from`,
  *   i.e. msg.sender. That is the right grain for the dashboard's "unique wallets", and the wrong
@@ -85,6 +97,20 @@ export function recentActivityCutoffDay(
  *   the executor appears under its own address and `canonicalAddress` rolls it onto its owner at
  *   read time. Not `AccountActivity`: that is every token holder, Uniswap pools included, and a
  *   pool's P/L is its inventory — see `fetchRouterCollateralCounterparties`.
+ * - **Indexer `outcome` transfers against a pool** cover what is left: a wallet whose trades are
+ *   signed by someone else *and* that never split, merged or redeemed, so neither of the two
+ *   sources above can name it. Requiring a pool on the other side keeps this keyed on a trade
+ *   rather than on holding — see `fetchOutcomeTokenPoolCounterparties`.
+ * - **Wallets already materialized** in `pnl_leaderboard`. The two indexer scans are incremental
+ *   (see the watermark below), so without this a wallet they discovered once would never be offered
+ *   for refresh again and its row would freeze at the price of the day it was found. The analytics
+ *   half re-lists its own wallets on every run and does not need it.
+ *
+ * The indexer halves resume from a per-chain watermark instead of re-reading the whole history every
+ * run. `kind=outcome` is a far larger stream than `router_collateral`, and both scans stop at a page
+ * cap; persisting how far they got turns that cap from a silent truncation into a walk that reaches
+ * the head over successive runs. Pass `incremental: false` to scan from `cutoffDay` regardless —
+ * what a coverage comparison wants, and what it pays for.
  *
  * Market-scoped jobs keep the analytics-only path: the indexer view has no market dimension to
  * filter on, and widening those boards is not what this fixes.
@@ -101,21 +127,58 @@ export async function listLeaderboardCandidates(
      * candidates at all under the default.
      */
     cutoffDay?: number;
+    /** Resume the indexer scans from the persisted watermark, and advance it. Defaults to `true`. */
+    incremental?: boolean;
   },
 ): Promise<LeaderboardCandidate[]> {
   const cutoffDay = opts?.cutoffDay ?? recentActivityCutoffDay();
 
   if (marketIds === undefined) {
-    const [fromAnalytics, fromIndexer] = await Promise.all([
+    const incremental = opts?.incremental ?? true;
+    const watermark = incremental
+      ? await readCandidateScanWatermark(supabase, chainId)
+      : { routerCollateralTs: 0, outcomeTradeTs: 0 };
+    const scanned: CandidateScanWatermark = { ...watermark };
+
+    const [fromAnalytics, fromMaterialized, fromRouterCollateral, fromOutcomeTrades] = await Promise.all([
       listCandidatesFromWalletAnalytics(supabase, chainId, cutoffDay),
+      listCandidatesFromMaterialized(supabase, chainId),
       // Additive and best-effort: the indexer being down must not shrink the candidate list to
-      // nothing and blank out a board that the analytics half could still have refreshed.
-      listCandidatesFromRouterCollateral(chainId, cutoffDay).catch((error) => {
-        console.warn("pnl-leaderboard: indexer candidate scan failed", { chainId, error });
-        return [] as LeaderboardCandidate[];
-      }),
+      // nothing and blank out a board that the analytics half could still have refreshed. A failed
+      // scan leaves its watermark where it was, so the slice it missed is re-read next run.
+      listCandidatesFromScan(
+        () =>
+          fetchRouterCollateralCounterparties(
+            chainId as SupportedChain,
+            Math.max(cutoffDay, watermark.routerCollateralTs),
+          ),
+        (ts) => {
+          scanned.routerCollateralTs = ts;
+        },
+        { chainId, source: "router_collateral" },
+      ),
+      listCandidatesFromScan(
+        async () =>
+          fetchOutcomeTokenPoolCounterparties(
+            chainId as SupportedChain,
+            Math.max(cutoffDay, watermark.outcomeTradeTs),
+            await chainPoolAddressSet(supabase, chainId as SupportedChain),
+          ),
+        (ts) => {
+          scanned.outcomeTradeTs = ts;
+        },
+        { chainId, source: "outcome_pool" },
+      ),
     ]);
-    return mergeCandidates(fromAnalytics, fromIndexer);
+
+    if (
+      incremental &&
+      (scanned.routerCollateralTs > watermark.routerCollateralTs || scanned.outcomeTradeTs > watermark.outcomeTradeTs)
+    ) {
+      await writeCandidateScanWatermark(supabase, chainId, scanned);
+    }
+
+    return mergeCandidates(fromAnalytics, fromMaterialized, fromRouterCollateral, fromOutcomeTrades);
   }
   if (marketIds.length === 0) return [];
 
@@ -136,14 +199,28 @@ function mergeCandidates(...lists: LeaderboardCandidate[][]): LeaderboardCandida
 }
 
 /**
- * Candidates from the indexer: wallets whose primary collateral moved with a router.
+ * Adapt one indexer scan to the candidate shape, reporting how far it got.
  *
  * `lastTransferTimestamp` is floored to its UTC day so `lastActivityDay` stays the same unit the
  * analytics half produces — `rankRefreshCandidates` compares the two against each other.
+ *
+ * `onScanned` is only called on success: a scan that threw must not advance a watermark, or the
+ * slice it failed on is skipped forever.
  */
-async function listCandidatesFromRouterCollateral(chainId: number, cutoffDay: number): Promise<LeaderboardCandidate[]> {
-  const rows = await fetchRouterCollateralCounterparties(chainId as SupportedChain, cutoffDay);
-  return rows.map((row) => ({
+async function listCandidatesFromScan(
+  scan: () => Promise<CandidateScanResult>,
+  onScanned: (maxTimestamp: number) => void,
+  context: { chainId: number; source: string },
+): Promise<LeaderboardCandidate[]> {
+  let result: CandidateScanResult;
+  try {
+    result = await scan();
+  } catch (error) {
+    console.warn("pnl-leaderboard: indexer candidate scan failed", { ...context, error });
+    return [];
+  }
+  if (result.maxTimestamp > 0) onScanned(result.maxTimestamp);
+  return result.counterparties.map((row) => ({
     address: row.account,
     lastActivityDay: floorUtcDay(row.lastTransferTimestamp),
   }));
@@ -199,6 +276,31 @@ async function listCandidatesFromWalletAnalytics(
         .order("day", { ascending: true })
         .range(from, to),
     "analytics_daily_wallet unavailable",
+  );
+}
+
+/**
+ * Wallets that already have a row on this chain's protocol-wide board.
+ *
+ * Keeps everything the job has ever materialized eligible for refresh now that the indexer scans
+ * only hand back what is new. `lastActivityDay: 0` is deliberate: with no fresh activity to compare
+ * against, `refreshPriority` files these as merely old, behind anything that actually traded.
+ */
+async function listCandidatesFromMaterialized(
+  supabase: SupabaseClient<Database>,
+  chainId: number,
+): Promise<LeaderboardCandidate[]> {
+  return loadCandidateAddresses(
+    (from, to) =>
+      supabase
+        .from("pnl_leaderboard")
+        .select("address")
+        .eq("chain_id", chainId)
+        .eq("app_id", SEER_APP_ALL_ID)
+        .eq("period", "all")
+        .order("address", { ascending: true })
+        .range(from, to),
+    "pnl_leaderboard unavailable",
   );
 }
 

--- a/web/netlify/functions/utils/seerIndexerPortfolio.ts
+++ b/web/netlify/functions/utils/seerIndexerPortfolio.ts
@@ -72,8 +72,78 @@ export type RouterCollateralCounterparty = {
   lastTransferTimestamp: number;
 };
 
-/** Bound the scan so a runaway page loop cannot eat a background function's whole budget. */
-const MAX_ROUTER_COUNTERPARTY_PAGES = 100;
+/**
+ * One pass of an indexer candidate scan.
+ *
+ * `maxTimestamp` is the highest transfer timestamp the pass actually read, whether or not it ran out
+ * of pages, so the caller can persist it as a watermark and have the next pass resume there. `0`
+ * means the pass matched nothing, and the watermark must not move.
+ */
+export type CandidateScanResult = {
+  counterparties: RouterCollateralCounterparty[];
+  maxTimestamp: number;
+  reachedPageCap: boolean;
+};
+
+/** Bound a scan so a runaway page loop cannot eat a background function's whole budget. */
+const MAX_CANDIDATE_SCAN_PAGES = 100;
+
+const EMPTY_CANDIDATE_SCAN: CandidateScanResult = { counterparties: [], maxTimestamp: 0, reachedPageCap: false };
+
+/**
+ * Page `Transfer` rows of one `kind` in timestamp order, keeping the wallets `accountsOf` names.
+ *
+ * The page cap is not a truncation: the caller persists `maxTimestamp` either way, so hitting it
+ * defers the rest of the history to the next run instead of dropping it. Ordering ascending is what
+ * makes that safe — a descending scan would resume from a moving head and never reach the tail.
+ */
+async function scanTransferCandidates(args: {
+  chainId: SupportedChain;
+  kind: string;
+  minTimestamp: number;
+  accountsOf: (row: { from: string; to: string }) => string[];
+}): Promise<CandidateScanResult> {
+  const sdk = seerEnvioSdk(args.chainId);
+  const lastByAccount = new Map<string, number>();
+  let maxTimestamp = 0;
+  let offset = 0;
+
+  for (let page = 0; page < MAX_CANDIDATE_SCAN_PAGES; page++) {
+    const { Transfer: rows } = await sdk.GetTransfers({
+      limit: PAGE,
+      offset,
+      orderBy: [{ timestamp: Order_By.Asc }, { logIndex: Order_By.Asc }],
+      where: {
+        chainId: { _eq: String(args.chainId) },
+        kind: { _eq: args.kind },
+        ...(args.minTimestamp > 0 ? { timestamp: { _gte: String(args.minTimestamp) } } : {}),
+      },
+    });
+    for (const row of rows) {
+      const timestamp = Number(row.timestamp);
+      if (timestamp > maxTimestamp) maxTimestamp = timestamp;
+      for (const account of args.accountsOf(row)) {
+        lastByAccount.set(account, Math.max(lastByAccount.get(account) ?? 0, timestamp));
+      }
+    }
+    if (rows.length < PAGE) {
+      return { counterparties: toCounterparties(lastByAccount), maxTimestamp, reachedPageCap: false };
+    }
+    offset += PAGE;
+  }
+
+  console.warn("seerIndexerPortfolio: candidate scan hit the page cap", {
+    chainId: args.chainId,
+    kind: args.kind,
+    scanned: lastByAccount.size,
+    resumeFrom: maxTimestamp,
+  });
+  return { counterparties: toCounterparties(lastByAccount), maxTimestamp, reachedPageCap: true };
+}
+
+function toCounterparties(lastByAccount: Map<string, number>): RouterCollateralCounterparty[] {
+  return [...lastByAccount].map(([account, lastTransferTimestamp]) => ({ account, lastTransferTimestamp }));
+}
 
 /**
  * Every wallet whose primary collateral moved with a Seer router on `chainId` at or after
@@ -92,45 +162,77 @@ const MAX_ROUTER_COUNTERPARTY_PAGES = 100;
  * from 15th place down at ~$87 each was the result on Optimism. A pool never moves collateral with
  * the router, so this scan excludes it structurally rather than by probing bytecode.
  *
- * Not covered: an executor that only ever bought outcome tokens on the DEX and never split, merged
- * or redeemed. Its swaps are in the DEX subgraph, not here.
+ * Not covered here: a wallet that only ever bought and sold outcome tokens against a pool and never
+ * split, merged or redeemed. That is what `fetchOutcomeTokenPoolCounterparties` is for.
  */
 export async function fetchRouterCollateralCounterparties(
   chainId: SupportedChain,
   minTimestamp = 0,
-): Promise<RouterCollateralCounterparty[]> {
-  const sdk = seerEnvioSdk(chainId);
+): Promise<CandidateScanResult> {
   const routers = routerAddressSet(chainId);
-  const lastByAccount = new Map<string, number>();
-  let offset = 0;
-  for (let page = 0; page < MAX_ROUTER_COUNTERPARTY_PAGES; page++) {
-    const { Transfer: rows } = await sdk.GetTransfers({
-      limit: PAGE,
-      offset,
-      orderBy: [{ timestamp: Order_By.Asc }, { logIndex: Order_By.Asc }],
-      where: {
-        chainId: { _eq: String(chainId) },
-        kind: { _eq: "router_collateral" },
-        ...(minTimestamp > 0 ? { timestamp: { _gte: String(minTimestamp) } } : {}),
-      },
-    });
-    for (const row of rows) {
+  return scanTransferCandidates({
+    chainId,
+    kind: "router_collateral",
+    minTimestamp,
+    accountsOf: (row) => {
+      const accounts: string[] = [];
       for (const party of [row.from, row.to]) {
         const account = party.toLowerCase();
         if (routers.has(account) || account === ZERO_ADDRESS) continue;
-        lastByAccount.set(account, Math.max(lastByAccount.get(account) ?? 0, Number(row.timestamp)));
+        accounts.push(account);
       }
-    }
-    if (rows.length < PAGE) {
-      return [...lastByAccount].map(([account, lastTransferTimestamp]) => ({ account, lastTransferTimestamp }));
-    }
-    offset += PAGE;
-  }
-  console.warn("seerIndexerPortfolio: router collateral scan hit the page cap", {
-    chainId,
-    scanned: lastByAccount.size,
+      return accounts;
+    },
   });
-  return [...lastByAccount].map(([account, lastTransferTimestamp]) => ({ account, lastTransferTimestamp }));
+}
+
+/**
+ * Every wallet that moved outcome tokens against an AMM pool on `chainId` at or after
+ * `minTimestamp` — the non-pool side of `Transfer kind=outcome` when the other side is a pool.
+ *
+ * The third candidate source, and it exists for the population the other two structurally cannot
+ * see: a wallet whose transactions are signed by somebody else *and* that never touched a router.
+ * A DeepFunding TradeExecutor driven by a browser session key is the live example — analytics books
+ * the session key, and a wallet that only swaps never moves primary collateral with the router — but
+ * a Safe, an ERC-4337 account and a sponsored 7702 EOA land in the same hole.
+ *
+ * Requiring a pool on the other side is what keeps this a trader signal rather than a holder one.
+ * `AccountActivity` was tried and reverted (`c6d87eac`): holding an outcome token is something a
+ * Uniswap pool does too, and a pool's P/L is the value of its inventory. Moving outcome tokens
+ * *against* a pool is something only its counterparty does, so pools drop out on both sides — a pool
+ * is never the non-pool side of its own transfer — and so do airdrops and OTC transfers between
+ * wallets, which name nobody who traded.
+ *
+ * `poolAddresses` failing short is safe in the direction that matters: an unknown pool costs a
+ * candidate, and can never promote a pool into one. An empty set disables the scan.
+ *
+ * Not covered: CoW Swap. The pool's counterparty there is the settlement contract, and the trader
+ * receives in a second transfer that touches no pool.
+ */
+export async function fetchOutcomeTokenPoolCounterparties(
+  chainId: SupportedChain,
+  minTimestamp: number,
+  poolAddresses: ReadonlySet<string>,
+): Promise<CandidateScanResult> {
+  if (poolAddresses.size === 0) return EMPTY_CANDIDATE_SCAN;
+  const routers = routerAddressSet(chainId);
+
+  return scanTransferCandidates({
+    chainId,
+    kind: "outcome",
+    minTimestamp,
+    accountsOf: (row) => {
+      const from = row.from.toLowerCase();
+      const to = row.to.toLowerCase();
+      const fromIsPool = poolAddresses.has(from);
+      const toIsPool = poolAddresses.has(to);
+      // Both sides pool is a direct hop between two pools; neither side pool is not a trade.
+      if (fromIsPool === toIsPool) return [];
+      const account = fromIsPool ? to : from;
+      if (routers.has(account) || account === ZERO_ADDRESS) return [];
+      return [account];
+    },
+  });
 }
 
 /**


### PR DESCRIPTION
A wallet whose transactions are signed by someone else and that never split, merged or redeemed is invisible to both existing candidate sources: analytics is keyed by tx_from, so it books the signer, and the router collateral scan never sees it. A DeepFunding TradeExecutor driven by a browser session key is the live case; a Safe, a 4337 account and a sponsored 7702 EOA land in the same hole.

Add a third source, fetchOutcomeTokenPoolCounterparties: Transfer kind=outcome, keeping the non-pool side only when the other side is a pool. That keeps the signal keyed on a trade rather than on holding, so pools drop out on both sides and airdrops and OTC transfers name nobody, which is the rule c6d87eac had to restore after AccountActivity put ~1,100 pools on the boards. The pool set comes from the chain's markets via getMarketPoolsPairs and fetchPools; an incomplete set costs a candidate and can never admit a pool, and an empty set disables the scan.

Both indexer scans now resume from a per-chain watermark in key_value instead of re-reading the whole history. This also fixes a latent truncation: the scans page timestamp ascending behind a 100-page cap, so a chain past that cap only ever handed back its oldest transfers and no recent wallet could become a candidate. A failed scan leaves its watermark where it was, so the slice it missed is read again. ?rescanCandidates=1 rewinds to the start of history, which is what a reindex or a widened candidate rule needs.

Since the scans now only return what is new, add the wallets already materialized in pnl_leaderboard as a fourth source, or a wallet discovered once would never be offered for refresh again and its row would freeze at the price of the day it was found.

Not covered: CoW Swap, where the pool's counterparty is the settlement contract and the trader receives in a second transfer that touches no pool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded P/L leaderboard coverage to include wallets interacting with outcome-token markets, including wallets without previously recorded trades.
  * Added more reliable incremental updates so newly discovered wallets can be included in future leaderboard refreshes.
  * Added support for complete candidate scans when a full refresh is requested.

* **Bug Fixes**
  * Improved leaderboard refresh consistency by preserving previously discovered wallets and handling scan progress more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->