### PR TITLE
Keep the trade widget's selector and values across unmounts

### DIFF
--- a/web/src/components/Market/SwapTokens/SwapTokens.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokens.tsx
@@ -1,4 +1,5 @@
 import { Dropdown } from "@/components/Dropdown";
+import { useMarketTradeDraft, useTradeOrderType } from "@/hooks/useTradeFormDraft";
 import { getLiquidityUrlByMarket, isFillToEstimateEnabled } from "@seer-pm/sdk";
 import { Market } from "@seer-pm/sdk";
 import type { Token } from "@seer-pm/sdk";
@@ -9,8 +10,6 @@ import { SwapTokensFillToEstimate } from "./SwapTokensFillToEstimate";
 import { SwapTokensLimitUpto } from "./SwapTokensLimitUpTo";
 import { SwapTokensMarket } from "./SwapTokensMarket";
 import SwapTokensMaxSlippage from "./SwapTokensMaxSlippage";
-
-type SwapOrderType = "market" | "limit" | "fill-to-estimate";
 
 interface SwapTokensProps {
   market: Market;
@@ -31,7 +30,9 @@ export function SwapTokens({
   fixedCollateral,
   onOutcomeChange,
 }: SwapTokensProps) {
-  const [orderType, setOrderType] = useState<SwapOrderType>("market");
+  // The order type lives in the draft store so it survives the widget unmounting.
+  const orderType = useTradeOrderType(market);
+  const { setDraft } = useMarketTradeDraft(market);
   const [isShowMaxSlippage, setShowMaxSlippage] = useState(false);
 
   const outcomeText = market.outcomes[outcomeIndex];
@@ -73,7 +74,7 @@ export function SwapTokens({
               <Dropdown
                 options={orderTypeOptions}
                 value={orderType}
-                onClick={(type) => setOrderType(type)}
+                onClick={(value) => setDraft({ orderType: value })}
                 defaultLabel="Order Type"
               />
             </div>

--- a/web/src/components/Market/SwapTokens/SwapTokensFillToEstimate.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensFillToEstimate.tsx
@@ -51,7 +51,7 @@ export function SwapTokensFillToEstimate({
 }: SwapTokensFillToEstimateProps) {
   const { address: account } = useAccount();
   const wagmiConfig = useConfig();
-  const { getDraft, setDraft, clearDraft } = useMarketTradeDraft(market);
+  const { getDraft, setDraft } = useMarketTradeDraft(market);
   // Read once: from here on this panel owns the values and writes them back to the draft.
   const [draft] = useState(() => getDraft()?.fillToEstimate);
   const maxSlippage = useGlobalState((state) => state.maxSlippage);
@@ -73,6 +73,7 @@ export function SwapTokensFillToEstimate({
     formState: { errors },
     reset,
     setValue,
+    trigger,
   } = useForm<SwapFormValues>({
     mode: "all",
     defaultValues: {
@@ -157,6 +158,14 @@ export function SwapTokensFillToEstimate({
     setDraft({ fillToEstimate: { targetEstimate: targetEstimateInput, maxCollateralToUse: maxCollateralInput } });
   }, [targetEstimateInput, maxCollateralInput, setDraft]);
 
+  useEffect(() => {
+    // Re-validate once the balance is known: a value restored from the draft was never
+    // typed, and one typed while the balance was still loading validated against 0.
+    if (!isFetchingBalance && maxCollateralInput) {
+      trigger("maxCollateralToUse");
+    }
+  }, [collateralBalance, isFetchingBalance]);
+
   const currentEstimateLabel = useMemo(() => formatCurrentEstimate(odds, market), [odds, market]);
   const marketUnit = getMarketUnit(market);
 
@@ -171,9 +180,9 @@ export function SwapTokensFillToEstimate({
   const fillToEstimateTrade = useFillToEstimateTrade(() => {
     closeConfirmModal();
     // Explicit values: the defaults were seeded from the draft, so a bare reset()
-    // would put the traded values back instead of clearing the form.
+    // would put the traded values back instead of clearing the form. The persistence
+    // effect then writes the cleared values to the draft; the order type is left alone.
     reset({ targetEstimate: "", maxCollateralToUse: "" });
-    clearDraft();
   });
   const { legExecutionStatuses } = fillToEstimateTrade;
 

--- a/web/src/components/Market/SwapTokens/SwapTokensFillToEstimate.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensFillToEstimate.tsx
@@ -3,7 +3,7 @@ import { getOutcomeTokenForIndex, useFillToEstimatePlan } from "@/hooks/fill-to-
 import { useFillToEstimateTrade } from "@/hooks/fill-to-estimate/useFillToEstimateTrade";
 import { useGlobalState } from "@/hooks/useGlobalState";
 import { useModal } from "@/hooks/useModal";
-import { useMarketTradeDraft } from "@/hooks/useTradeFormDraft";
+import { useMarketTradeDraft, useOnTradeDraftCleared } from "@/hooks/useTradeFormDraft";
 import { formatCurrentEstimate, formatFillToEstimateLegPreview } from "@/lib/fill-to-estimate-display";
 import { Parameter, QuestionIcon } from "@/lib/icons";
 import { displayBalance, displayNumber } from "@/lib/utils";
@@ -177,11 +177,12 @@ export function SwapTokensFillToEstimate({
 
   const [isQuoting, setIsQuoting] = useState(false);
 
+  // Explicit values: the defaults were seeded from the draft, so a bare reset()
+  // would put the traded values back instead of clearing the form.
+  useOnTradeDraftCleared(market, "fillToEstimate", () => reset({ targetEstimate: "", maxCollateralToUse: "" }));
+
   const fillToEstimateTrade = useFillToEstimateTrade(() => {
     closeConfirmModal();
-    // Explicit values: the defaults were seeded from the draft, so a bare reset()
-    // would put the traded values back instead of clearing the form.
-    reset({ targetEstimate: "", maxCollateralToUse: "" });
     clearDraft("fillToEstimate");
   });
   const { legExecutionStatuses } = fillToEstimateTrade;

--- a/web/src/components/Market/SwapTokens/SwapTokensFillToEstimate.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensFillToEstimate.tsx
@@ -51,7 +51,7 @@ export function SwapTokensFillToEstimate({
 }: SwapTokensFillToEstimateProps) {
   const { address: account } = useAccount();
   const wagmiConfig = useConfig();
-  const { getDraft, setDraft } = useMarketTradeDraft(market);
+  const { getDraft, setDraft, clearDraft } = useMarketTradeDraft(market);
   // Read once: from here on this panel owns the values and writes them back to the draft.
   const [draft] = useState(() => getDraft()?.fillToEstimate);
   const maxSlippage = useGlobalState((state) => state.maxSlippage);
@@ -180,9 +180,9 @@ export function SwapTokensFillToEstimate({
   const fillToEstimateTrade = useFillToEstimateTrade(() => {
     closeConfirmModal();
     // Explicit values: the defaults were seeded from the draft, so a bare reset()
-    // would put the traded values back instead of clearing the form. The persistence
-    // effect then writes the cleared values to the draft; the order type is left alone.
+    // would put the traded values back instead of clearing the form.
     reset({ targetEstimate: "", maxCollateralToUse: "" });
+    clearDraft("fillToEstimate");
   });
   const { legExecutionStatuses } = fillToEstimateTrade;
 

--- a/web/src/components/Market/SwapTokens/SwapTokensFillToEstimate.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensFillToEstimate.tsx
@@ -3,6 +3,7 @@ import { getOutcomeTokenForIndex, useFillToEstimatePlan } from "@/hooks/fill-to-
 import { useFillToEstimateTrade } from "@/hooks/fill-to-estimate/useFillToEstimateTrade";
 import { useGlobalState } from "@/hooks/useGlobalState";
 import { useModal } from "@/hooks/useModal";
+import { useMarketTradeDraft } from "@/hooks/useTradeFormDraft";
 import { formatCurrentEstimate, formatFillToEstimateLegPreview } from "@/lib/fill-to-estimate-display";
 import { Parameter, QuestionIcon } from "@/lib/icons";
 import { displayBalance, displayNumber } from "@/lib/utils";
@@ -50,6 +51,9 @@ export function SwapTokensFillToEstimate({
 }: SwapTokensFillToEstimateProps) {
   const { address: account } = useAccount();
   const wagmiConfig = useConfig();
+  const { getDraft, setDraft, clearDraft } = useMarketTradeDraft(market);
+  // Read once: from here on this panel owns the values and writes them back to the draft.
+  const [draft] = useState(() => getDraft()?.fillToEstimate);
   const maxSlippage = useGlobalState((state) => state.maxSlippage);
   const selectedCollateral = useMemo(
     () => getFillToEstimateCollateral(market, fixedCollateral),
@@ -72,8 +76,8 @@ export function SwapTokensFillToEstimate({
   } = useForm<SwapFormValues>({
     mode: "all",
     defaultValues: {
-      targetEstimate: "",
-      maxCollateralToUse: "",
+      targetEstimate: draft?.targetEstimate ?? "",
+      maxCollateralToUse: draft?.maxCollateralToUse ?? "",
     },
   });
 
@@ -149,6 +153,10 @@ export function SwapTokensFillToEstimate({
     autoAdjustMaxCollateralForTargetRef.current = undefined;
   }, [parsedTargetEstimate, necessaryMaxCollateral, parsedMaxCollateralToUse, selectedCollateral.decimals, setValue]);
 
+  useEffect(() => {
+    setDraft({ fillToEstimate: { targetEstimate: targetEstimateInput, maxCollateralToUse: maxCollateralInput } });
+  }, [targetEstimateInput, maxCollateralInput, setDraft]);
+
   const currentEstimateLabel = useMemo(() => formatCurrentEstimate(odds, market), [odds, market]);
   const marketUnit = getMarketUnit(market);
 
@@ -162,7 +170,10 @@ export function SwapTokensFillToEstimate({
 
   const fillToEstimateTrade = useFillToEstimateTrade(() => {
     closeConfirmModal();
-    reset();
+    // Explicit values: the defaults were seeded from the draft, so a bare reset()
+    // would put the traded values back instead of clearing the form.
+    reset({ targetEstimate: "", maxCollateralToUse: "" });
+    clearDraft();
   });
   const { legExecutionStatuses } = fillToEstimateTrade;
 

--- a/web/src/components/Market/SwapTokens/SwapTokensLimitUpTo.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensLimitUpTo.tsx
@@ -6,7 +6,7 @@ import { useTradeConditions } from "@/hooks/trade/useTradeConditions";
 import useDebounce from "@/hooks/useDebounce";
 import { useGlobalState } from "@/hooks/useGlobalState";
 import { useModal } from "@/hooks/useModal";
-import { useMarketTradeDraft } from "@/hooks/useTradeFormDraft";
+import { useMarketTradeDraft, useOnTradeDraftCleared } from "@/hooks/useTradeFormDraft";
 import { Parameter, QuestionIcon } from "@/lib/icons";
 import { paths } from "@/lib/paths";
 import { isDraftForOutcome } from "@/lib/trade-draft";
@@ -169,6 +169,10 @@ export function SwapTokensLimitUpto({
     tradeType,
     maxSlippage,
   );
+  // Explicit values: the defaults were seeded from the draft, so a bare reset()
+  // would put the traded target price back instead of clearing the form.
+  useOnTradeDraftCleared(market, "limit", () => reset({ type: "buy", amount: "", amountOut: "", limitPrice: "" }));
+
   const {
     tradeTokens,
     approvals: { data: missingApprovals = [], isLoading: isLoadingApprovals },
@@ -177,9 +181,6 @@ export function SwapTokensLimitUpto({
     quoteData?.trade,
     isTradingCreditsCollateral,
     async () => {
-      // Explicit values: the defaults were seeded from the draft, so a bare reset()
-      // would put the traded target price back instead of clearing the form.
-      reset({ type: "buy", amount: "", amountOut: "", limitPrice: "" });
       clearDraft("limit");
       closeConfirmSwapModal();
     },

--- a/web/src/components/Market/SwapTokens/SwapTokensLimitUpTo.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensLimitUpTo.tsx
@@ -61,7 +61,7 @@ export function SwapTokensLimitUpto({
   onOutcomeChange,
 }: SwapTokensLimitUptoProps) {
   const limitPriceRef = useRef<HTMLInputElement | null>(null);
-  const { getDraft, setDraft, clearDraft } = useMarketTradeDraft(market);
+  const { getDraft, setDraft } = useMarketTradeDraft(market);
   // Read once: only the target price is kept, the amounts below are derived from it.
   // A draft typed against another outcome is ignored: the price would not mean the same thing.
   const [draft] = useState(() => {
@@ -178,9 +178,9 @@ export function SwapTokensLimitUpto({
     isTradingCreditsCollateral,
     async () => {
       // Explicit values: the defaults were seeded from the draft, so a bare reset()
-      // would put the traded target price back instead of clearing the form.
+      // would put the traded target price back instead of clearing the form. The
+      // persistence effect then writes the cleared price to the draft; the order type is left alone.
       reset({ type: "buy", amount: "", amountOut: "", limitPrice: "" });
-      clearDraft();
       closeConfirmSwapModal();
     },
     market,

--- a/web/src/components/Market/SwapTokens/SwapTokensLimitUpTo.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensLimitUpTo.tsx
@@ -10,7 +10,7 @@ import { useMarketTradeDraft, useOnTradeDraftCleared } from "@/hooks/useTradeFor
 import { Parameter, QuestionIcon } from "@/lib/icons";
 import { paths } from "@/lib/paths";
 import { isDraftForOutcome } from "@/lib/trade-draft";
-import { displayBalance, isTwoStringsEqual, isUndefined } from "@/lib/utils";
+import { displayBalance, displayNumber, isTwoStringsEqual, isUndefined } from "@/lib/utils";
 import { useQuoteTrade } from "@seer-pm/react";
 import { isTradingCredits } from "@seer-pm/sdk";
 import { Market } from "@seer-pm/sdk";
@@ -552,7 +552,7 @@ export function SwapTokensLimitUpto({
               <div className="shimmer-container ml-2 w-[100px]" />
             ) : (
               <div className="flex items-center gap-2">
-                {collateralPerShare} {selectedCollateral.symbol}
+                {displayNumber(collateralPerShare)} {selectedCollateral.symbol}
                 {isSecondaryCollateral && (
                   <span className="tooltip">
                     <p className="tooltiptext">

--- a/web/src/components/Market/SwapTokens/SwapTokensLimitUpTo.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensLimitUpTo.tsx
@@ -61,7 +61,7 @@ export function SwapTokensLimitUpto({
   onOutcomeChange,
 }: SwapTokensLimitUptoProps) {
   const limitPriceRef = useRef<HTMLInputElement | null>(null);
-  const { getDraft, setDraft } = useMarketTradeDraft(market);
+  const { getDraft, setDraft, clearDraft } = useMarketTradeDraft(market);
   // Read once: only the target price is kept, the amounts below are derived from it.
   // A draft typed against another outcome is ignored: the price would not mean the same thing.
   const [draft] = useState(() => {
@@ -178,9 +178,9 @@ export function SwapTokensLimitUpto({
     isTradingCreditsCollateral,
     async () => {
       // Explicit values: the defaults were seeded from the draft, so a bare reset()
-      // would put the traded target price back instead of clearing the form. The
-      // persistence effect then writes the cleared price to the draft; the order type is left alone.
+      // would put the traded target price back instead of clearing the form.
       reset({ type: "buy", amount: "", amountOut: "", limitPrice: "" });
+      clearDraft("limit");
       closeConfirmSwapModal();
     },
     market,

--- a/web/src/components/Market/SwapTokens/SwapTokensLimitUpTo.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensLimitUpTo.tsx
@@ -6,8 +6,10 @@ import { useTradeConditions } from "@/hooks/trade/useTradeConditions";
 import useDebounce from "@/hooks/useDebounce";
 import { useGlobalState } from "@/hooks/useGlobalState";
 import { useModal } from "@/hooks/useModal";
+import { useMarketTradeDraft } from "@/hooks/useTradeFormDraft";
 import { Parameter, QuestionIcon } from "@/lib/icons";
 import { paths } from "@/lib/paths";
+import { isDraftForOutcome } from "@/lib/trade-draft";
 import { displayBalance, isTwoStringsEqual, isUndefined } from "@/lib/utils";
 import { useQuoteTrade } from "@seer-pm/react";
 import { isTradingCredits } from "@seer-pm/sdk";
@@ -59,6 +61,13 @@ export function SwapTokensLimitUpto({
   onOutcomeChange,
 }: SwapTokensLimitUptoProps) {
   const limitPriceRef = useRef<HTMLInputElement | null>(null);
+  const { getDraft, setDraft, clearDraft } = useMarketTradeDraft(market);
+  // Read once: only the target price is kept, the amounts below are derived from it.
+  // A draft typed against another outcome is ignored: the price would not mean the same thing.
+  const [draft] = useState(() => {
+    const limitDraft = getDraft()?.limit;
+    return isDraftForOutcome(limitDraft, outcomeToken.address) ? limitDraft : undefined;
+  });
   const [swapType, setSwapType] = useState<"buy" | "sell">("buy");
   const [tradeType, setTradeType] = useState(TradeType.EXACT_INPUT);
   const [isUseMax, setUseMax] = useState(false);
@@ -77,7 +86,7 @@ export function SwapTokensLimitUpto({
       type: "buy",
       amount: "",
       amountOut: "",
-      limitPrice: "",
+      limitPrice: draft?.limitPrice ?? "",
     },
   });
 
@@ -168,7 +177,10 @@ export function SwapTokensLimitUpto({
     quoteData?.trade,
     isTradingCreditsCollateral,
     async () => {
-      reset();
+      // Explicit values: the defaults were seeded from the draft, so a bare reset()
+      // would put the traded target price back instead of clearing the form.
+      reset({ type: "buy", amount: "", amountOut: "", limitPrice: "" });
+      clearDraft();
       closeConfirmSwapModal();
     },
     market,
@@ -272,10 +284,23 @@ export function SwapTokensLimitUpto({
   }, [balance]);
 
   useEffect(() => {
-    resetField("limitPrice");
+    setDraft({ limit: { outcomeToken: outcomeToken.address, limitPrice } });
+  }, [outcomeToken.address, limitPrice, setDraft]);
+
+  // Clear the inputs when the traded pair changes, but never on the first render:
+  // that would throw away the draft we just restored. defaultValue "" because the
+  // form defaults were seeded from that same draft.
+  const pairKey = `${selectedCollateral.address}-${outcomeToken.address}`;
+  const pairKeyRef = useRef(pairKey);
+  useEffect(() => {
+    if (pairKeyRef.current === pairKey) {
+      return;
+    }
+    pairKeyRef.current = pairKey;
+    resetField("limitPrice", { defaultValue: "" });
     resetField("amount");
     resetField("amountOut");
-  }, [selectedCollateral.address, outcomeToken.address]);
+  }, [pairKey]);
 
   useEffect(() => {
     if (tradeType === TradeType.EXACT_INPUT) {

--- a/web/src/components/Market/SwapTokens/SwapTokensMarket.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensMarket.tsx
@@ -572,7 +572,7 @@ export function SwapTokensMarket({
               />
             ) : (
               <div className="flex items-center gap-2">
-                {collateralPerShare.toFixed(3)} {selectedCollateral.symbol}
+                {displayNumber(collateralPerShare)} {selectedCollateral.symbol}
                 {isSecondaryCollateral && (
                   <span className="tooltip">
                     <p className="tooltiptext">

--- a/web/src/components/Market/SwapTokens/SwapTokensMarket.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensMarket.tsx
@@ -116,7 +116,7 @@ export function SwapTokensMarket({
 }: SwapTokensMarketProps) {
   const amountRef = useRef<HTMLInputElement | null>(null);
   const amountOutRef = useRef<HTMLInputElement | null>(null);
-  const { getDraft, setDraft, clearDraft } = useMarketTradeDraft(market);
+  const { getDraft, setDraft } = useMarketTradeDraft(market);
   // Read once: from here on this panel owns the values and writes them back to the draft.
   // A draft typed against another outcome is ignored: the amounts would not mean the same thing.
   const [draft] = useState(() => {
@@ -153,7 +153,8 @@ export function SwapTokensMarket({
 
   const resetForm = () => {
     // Explicit values: the defaults were seeded from the draft, so a bare reset()
-    // would put the traded amount back instead of clearing the form.
+    // would put the traded amount back instead of clearing the form. The persistence
+    // effect then writes the cleared amounts to the draft; the order type is left alone.
     reset({ type: swapType, amount: "", amountOut: "" });
   };
 
@@ -219,7 +220,6 @@ export function SwapTokensMarket({
     isTradingCreditsCollateral,
     async () => {
       resetForm();
-      clearDraft();
       closeConfirmSwapModal();
     },
     market,

--- a/web/src/components/Market/SwapTokens/SwapTokensMarket.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensMarket.tsx
@@ -5,7 +5,9 @@ import { useModal } from "@/hooks/useModal";
 import { usePriceFromVolume } from "@/hooks/liquidity/usePriceUntilVolume";
 import { useTradeConditions } from "@/hooks/trade/useTradeConditions";
 import { useGlobalState } from "@/hooks/useGlobalState";
+import { useMarketTradeDraft } from "@/hooks/useTradeFormDraft";
 import { ArrowDown, Parameter, QuestionIcon } from "@/lib/icons";
+import { isDraftForOutcome } from "@/lib/trade-draft";
 import { displayBalance, displayNumber, isUndefined } from "@/lib/utils";
 import { useQuoteTrade } from "@seer-pm/react";
 import { isTradingCredits } from "@seer-pm/sdk";
@@ -114,17 +116,24 @@ export function SwapTokensMarket({
 }: SwapTokensMarketProps) {
   const amountRef = useRef<HTMLInputElement | null>(null);
   const amountOutRef = useRef<HTMLInputElement | null>(null);
-  const [tradeType, setTradeType] = useState(TradeType.EXACT_INPUT);
-  const [swapType, setSwapType] = useState<"buy" | "sell">("buy");
+  const { getDraft, setDraft, clearDraft } = useMarketTradeDraft(market);
+  // Read once: from here on this panel owns the values and writes them back to the draft.
+  // A draft typed against another outcome is ignored: the amounts would not mean the same thing.
+  const [draft] = useState(() => {
+    const marketDraft = getDraft()?.market;
+    return isDraftForOutcome(marketDraft, outcomeToken.address) ? marketDraft : undefined;
+  });
+  const [tradeType, setTradeType] = useState(draft?.tradeType ?? TradeType.EXACT_INPUT);
+  const [swapType, setSwapType] = useState<"buy" | "sell">(draft?.swapType ?? "buy");
   const [focusContainer, setFocusContainer] = useState(0);
   const setPreferredCollateral = useGlobalState((state) => state.setPreferredCollateral);
   const primaryCollateral = getActivePrimaryCollateral(market.chainId);
   const useFormReturn = useForm<SwapFormValues>({
     mode: "all",
     defaultValues: {
-      type: "buy",
-      amount: "",
-      amountOut: "",
+      type: draft?.swapType ?? "buy",
+      amount: draft?.amount ?? "",
+      amountOut: draft?.amountOut ?? "",
     },
   });
 
@@ -141,6 +150,12 @@ export function SwapTokensMarket({
   } = useFormReturn;
 
   const [amount, amountOut] = watch(["amount", "amountOut"]);
+
+  const resetForm = () => {
+    // Explicit values: the defaults were seeded from the draft, so a bare reset()
+    // would put the traded amount back instead of clearing the form.
+    reset({ type: swapType, amount: "", amountOut: "" });
+  };
 
   const {
     Modal: ConfirmSwapModal,
@@ -203,7 +218,8 @@ export function SwapTokensMarket({
     quoteData?.trade,
     isTradingCreditsCollateral,
     async () => {
-      reset();
+      resetForm();
+      clearDraft();
       closeConfirmSwapModal();
     },
     market,
@@ -259,8 +275,10 @@ export function SwapTokensMarket({
     getOutcomeTokenVolume(quoteData, swapType),
   );
   const resetInputs = () => {
-    resetField("amount");
-    resetField("amountOut");
+    // defaultValue "": the form defaults were seeded from the draft, so resetting a
+    // field to its default would bring the restored amount back instead of clearing it.
+    resetField("amount", { defaultValue: "" });
+    resetField("amountOut", { defaultValue: "" });
   };
 
   const renderButtons = () => {
@@ -300,14 +318,38 @@ export function SwapTokensMarket({
   // useEffects
 
   useEffect(() => {
-    dirtyFields["amount"] && trigger("amount");
-  }, [balance]);
+    // Re-validate once the balance is known. An amount restored from the draft was
+    // never typed, so it is not dirty: check the value itself, or the Swap button
+    // would stay disabled until the user touches the field.
+    if (!isFetchingBalance && (dirtyFields["amount"] || amount)) {
+      trigger("amount");
+    }
+  }, [balance, isFetchingBalance]);
 
   useEffect(() => {
+    setDraft({ market: { outcomeToken: outcomeToken.address, swapType, tradeType, amount, amountOut } });
+  }, [outcomeToken.address, swapType, tradeType, amount, amountOut, setDraft]);
+
+  // Clear the inputs when the traded pair changes, but never on the first render:
+  // that would throw away the draft we just restored.
+  const pairKey = `${swapType}-${selectedCollateral.address}-${outcomeToken.address}`;
+  const pairKeyRef = useRef(pairKey);
+  useEffect(() => {
+    if (pairKeyRef.current === pairKey) {
+      return;
+    }
+    pairKeyRef.current = pairKey;
     resetInputs();
-  }, [swapType, selectedCollateral.address, outcomeToken.address]);
+  }, [pairKey]);
 
+  const hasQuotedRef = useRef(false);
   useEffect(() => {
+    // Before the first quote lands there is nothing to derive from: leave the restored
+    // draft alone instead of blanking it out.
+    if (!hasQuotedRef.current && isUndefined(quoteData?.value)) {
+      return;
+    }
+    hasQuotedRef.current = true;
     if (tradeType === TradeType.EXACT_INPUT) {
       setValue("amountOut", receivedAmount ? receivedAmount.toString() : "", {
         shouldValidate: true,

--- a/web/src/components/Market/SwapTokens/SwapTokensMarket.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensMarket.tsx
@@ -116,7 +116,7 @@ export function SwapTokensMarket({
 }: SwapTokensMarketProps) {
   const amountRef = useRef<HTMLInputElement | null>(null);
   const amountOutRef = useRef<HTMLInputElement | null>(null);
-  const { getDraft, setDraft } = useMarketTradeDraft(market);
+  const { getDraft, setDraft, clearDraft } = useMarketTradeDraft(market);
   // Read once: from here on this panel owns the values and writes them back to the draft.
   // A draft typed against another outcome is ignored: the amounts would not mean the same thing.
   const [draft] = useState(() => {
@@ -153,8 +153,7 @@ export function SwapTokensMarket({
 
   const resetForm = () => {
     // Explicit values: the defaults were seeded from the draft, so a bare reset()
-    // would put the traded amount back instead of clearing the form. The persistence
-    // effect then writes the cleared amounts to the draft; the order type is left alone.
+    // would put the traded amount back instead of clearing the form.
     reset({ type: swapType, amount: "", amountOut: "" });
   };
 
@@ -220,6 +219,7 @@ export function SwapTokensMarket({
     isTradingCreditsCollateral,
     async () => {
       resetForm();
+      clearDraft("market");
       closeConfirmSwapModal();
     },
     market,

--- a/web/src/components/Market/SwapTokens/SwapTokensMarket.tsx
+++ b/web/src/components/Market/SwapTokens/SwapTokensMarket.tsx
@@ -5,7 +5,7 @@ import { useModal } from "@/hooks/useModal";
 import { usePriceFromVolume } from "@/hooks/liquidity/usePriceUntilVolume";
 import { useTradeConditions } from "@/hooks/trade/useTradeConditions";
 import { useGlobalState } from "@/hooks/useGlobalState";
-import { useMarketTradeDraft } from "@/hooks/useTradeFormDraft";
+import { useMarketTradeDraft, useOnTradeDraftCleared } from "@/hooks/useTradeFormDraft";
 import { ArrowDown, Parameter, QuestionIcon } from "@/lib/icons";
 import { isDraftForOutcome } from "@/lib/trade-draft";
 import { displayBalance, displayNumber, isUndefined } from "@/lib/utils";
@@ -151,11 +151,9 @@ export function SwapTokensMarket({
 
   const [amount, amountOut] = watch(["amount", "amountOut"]);
 
-  const resetForm = () => {
-    // Explicit values: the defaults were seeded from the draft, so a bare reset()
-    // would put the traded amount back instead of clearing the form.
-    reset({ type: swapType, amount: "", amountOut: "" });
-  };
+  // Explicit values: the defaults were seeded from the draft, so a bare reset()
+  // would put the traded amount back instead of clearing the form.
+  useOnTradeDraftCleared(market, "market", () => reset({ type: swapType, amount: "", amountOut: "" }));
 
   const {
     Modal: ConfirmSwapModal,
@@ -218,7 +216,6 @@ export function SwapTokensMarket({
     quoteData?.trade,
     isTradingCreditsCollateral,
     async () => {
-      resetForm();
       clearDraft("market");
       closeConfirmSwapModal();
     },

--- a/web/src/components/Market/SwapTokens/components/PotentialReturn/PotentialReturnResult.tsx
+++ b/web/src/components/Market/SwapTokens/components/PotentialReturn/PotentialReturnResult.tsx
@@ -43,7 +43,7 @@ export function PotentialReturnResult({
 
   return (
     <span className={clsx(returnPercentage >= 0 ? "text-success-primary" : "text-error-primary", "text-right")}>
-      {potentialReturn.toFixed(3)} {selectedCollateral.symbol} ({returnPercentage.toFixed(2)}
+      {potentialReturn.toFixed(2)} {selectedCollateral.symbol} ({returnPercentage.toFixed(2)}
       %)
     </span>
   );

--- a/web/src/hooks/useTradeFormDraft.ts
+++ b/web/src/hooks/useTradeFormDraft.ts
@@ -1,8 +1,10 @@
 import {
   type SwapOrderType,
   type TradeDraft,
+  type TradeDraftSection,
   type TradeDrafts,
   applyTradeDraft,
+  clearTradeDraftSection,
   getTradeDraftKey,
   readOrderType,
 } from "@/lib/trade-draft";
@@ -17,6 +19,7 @@ type State = {
 
 type Action = {
   setTradeDraft: (key: string, patch: TradeDraft) => void;
+  clearTradeDraftSection: (key: string, section: TradeDraftSection) => void;
 };
 
 /**
@@ -36,6 +39,10 @@ const useTradeFormDraft = create<State & Action>()(
         set((state) => ({
           drafts: applyTradeDraft(state.drafts, key, patch),
         })),
+      clearTradeDraftSection: (key: string, section: TradeDraftSection) =>
+        set((state) => ({
+          drafts: clearTradeDraftSection(state.drafts, key, section),
+        })),
     }),
     {
       name: "seer-trade-draft",
@@ -47,15 +54,22 @@ const useTradeFormDraft = create<State & Action>()(
 /**
  * Draft accessors for one market. `getDraft` reads a snapshot instead of subscribing:
  * the panels seed their form defaults from it once and own the value afterwards.
+ *
+ * `clearDraft` drops one panel's section right away, without waiting for that panel's
+ * persistence effect: after a trade the widget may already be unmounted (the outcome
+ * token reloads), so the effect never runs and a remount would restore the traded
+ * values. The order type is left alone so the widget stays on the same panel.
  */
 export function useMarketTradeDraft(market: Market) {
   const key = getTradeDraftKey(market.chainId, market.id);
   const setTradeDraft = useTradeFormDraft((state) => state.setTradeDraft);
+  const clearSection = useTradeFormDraft((state) => state.clearTradeDraftSection);
 
   const getDraft = useCallback(() => useTradeFormDraft.getState().drafts[key], [key]);
   const setDraft = useCallback((patch: TradeDraft) => setTradeDraft(key, patch), [key, setTradeDraft]);
+  const clearDraft = useCallback((section: TradeDraftSection) => clearSection(key, section), [key, clearSection]);
 
-  return { getDraft, setDraft };
+  return { getDraft, setDraft, clearDraft };
 }
 
 /** The stored order type for this market, sanitized against what the market offers. */

--- a/web/src/hooks/useTradeFormDraft.ts
+++ b/web/src/hooks/useTradeFormDraft.ts
@@ -1,0 +1,81 @@
+import {
+  type SwapOrderType,
+  type TradeDraft,
+  type TradeDrafts,
+  applyTradeDraft,
+  getTradeDraftKey,
+  readOrderType,
+  removeTradeDraft,
+} from "@/lib/trade-draft";
+import { type Market, isFillToEstimateEnabled } from "@seer-pm/sdk";
+import { useCallback } from "react";
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+type State = {
+  drafts: TradeDrafts;
+};
+
+type Action = {
+  setTradeDraft: (key: string, patch: TradeDraft) => void;
+  clearTradeDraft: (key: string) => void;
+};
+
+/**
+ * What the user typed in a market's trade widget, kept outside React so it survives
+ * the widget unmounting: switching order type, opening the max slippage screen, the
+ * mobile drawer tabs, or the outcome token reloading while the wallet is busy between
+ * an approval and the swap itself.
+ *
+ * Session storage (not local storage like `useGlobalState`): the draft should outlive
+ * a page reload in this tab, not the tab itself.
+ */
+const useTradeFormDraft = create<State & Action>()(
+  persist(
+    (set) => ({
+      drafts: {},
+      setTradeDraft: (key: string, patch: TradeDraft) =>
+        set((state) => ({
+          drafts: applyTradeDraft(state.drafts, key, patch),
+        })),
+      clearTradeDraft: (key: string) =>
+        set((state) => ({
+          drafts: removeTradeDraft(state.drafts, key),
+        })),
+    }),
+    {
+      name: "seer-trade-draft",
+      storage: createJSONStorage(() => sessionStorage),
+    },
+  ),
+);
+
+/**
+ * Draft accessors for one market. `getDraft` reads a snapshot instead of subscribing:
+ * the panels seed their form defaults from it once and own the value afterwards.
+ */
+export function useMarketTradeDraft(market: Market) {
+  const key = getTradeDraftKey(market.chainId, market.id);
+  const setTradeDraft = useTradeFormDraft((state) => state.setTradeDraft);
+  const clearTradeDraft = useTradeFormDraft((state) => state.clearTradeDraft);
+
+  const getDraft = useCallback(() => useTradeFormDraft.getState().drafts[key], [key]);
+  const setDraft = useCallback((patch: TradeDraft) => setTradeDraft(key, patch), [key, setTradeDraft]);
+  const clearDraft = useCallback(() => clearTradeDraft(key), [key, clearTradeDraft]);
+
+  return { getDraft, setDraft, clearDraft };
+}
+
+/** The stored order type for this market, sanitized against what the market offers. */
+export function useTradeOrderType(market: Market): SwapOrderType {
+  const key = getTradeDraftKey(market.chainId, market.id);
+
+  return useTradeFormDraft((state) =>
+    readOrderType(state.drafts[key]?.orderType, {
+      isGeneric: market.type === "Generic",
+      allowFillToEstimate: isFillToEstimateEnabled(market),
+    }),
+  );
+}
+
+export { useTradeFormDraft };

--- a/web/src/hooks/useTradeFormDraft.ts
+++ b/web/src/hooks/useTradeFormDraft.ts
@@ -5,7 +5,6 @@ import {
   applyTradeDraft,
   getTradeDraftKey,
   readOrderType,
-  removeTradeDraft,
 } from "@/lib/trade-draft";
 import { type Market, isFillToEstimateEnabled } from "@seer-pm/sdk";
 import { useCallback } from "react";
@@ -18,7 +17,6 @@ type State = {
 
 type Action = {
   setTradeDraft: (key: string, patch: TradeDraft) => void;
-  clearTradeDraft: (key: string) => void;
 };
 
 /**
@@ -38,10 +36,6 @@ const useTradeFormDraft = create<State & Action>()(
         set((state) => ({
           drafts: applyTradeDraft(state.drafts, key, patch),
         })),
-      clearTradeDraft: (key: string) =>
-        set((state) => ({
-          drafts: removeTradeDraft(state.drafts, key),
-        })),
     }),
     {
       name: "seer-trade-draft",
@@ -57,13 +51,11 @@ const useTradeFormDraft = create<State & Action>()(
 export function useMarketTradeDraft(market: Market) {
   const key = getTradeDraftKey(market.chainId, market.id);
   const setTradeDraft = useTradeFormDraft((state) => state.setTradeDraft);
-  const clearTradeDraft = useTradeFormDraft((state) => state.clearTradeDraft);
 
   const getDraft = useCallback(() => useTradeFormDraft.getState().drafts[key], [key]);
   const setDraft = useCallback((patch: TradeDraft) => setTradeDraft(key, patch), [key, setTradeDraft]);
-  const clearDraft = useCallback(() => clearTradeDraft(key), [key, clearTradeDraft]);
 
-  return { getDraft, setDraft, clearDraft };
+  return { getDraft, setDraft };
 }
 
 /** The stored order type for this market, sanitized against what the market offers. */

--- a/web/src/hooks/useTradeFormDraft.ts
+++ b/web/src/hooks/useTradeFormDraft.ts
@@ -9,7 +9,7 @@ import {
   readOrderType,
 } from "@/lib/trade-draft";
 import { type Market, isFillToEstimateEnabled } from "@seer-pm/sdk";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
@@ -55,10 +55,9 @@ const useTradeFormDraft = create<State & Action>()(
  * Draft accessors for one market. `getDraft` reads a snapshot instead of subscribing:
  * the panels seed their form defaults from it once and own the value afterwards.
  *
- * `clearDraft` drops one panel's section right away, without waiting for that panel's
- * persistence effect: after a trade the widget may already be unmounted (the outcome
- * token reloads), so the effect never runs and a remount would restore the traded
- * values. The order type is left alone so the widget stays on the same panel.
+ * `clearDraft` drops one panel's section after a trade. The order type is left alone
+ * so the widget stays on the same panel. The form itself is emptied by
+ * `useOnTradeDraftCleared`, not by the trade callback: see there.
  */
 export function useMarketTradeDraft(market: Market) {
   const key = getTradeDraftKey(market.chainId, market.id);
@@ -70,6 +69,31 @@ export function useMarketTradeDraft(market: Market) {
   const clearDraft = useCallback((section: TradeDraftSection) => clearSection(key, section), [key, clearSection]);
 
   return { getDraft, setDraft, clearDraft };
+}
+
+/**
+ * Run `onCleared` when this panel's draft section is dropped, i.e. when a trade went
+ * through. The widget returns null while the outcome token reloads, which happens
+ * during a trade, so the panel that started it may have been replaced by a fresh
+ * instance (seeded from the draft, so showing the traded values) by the time the
+ * trade callback fires. Calling reset() from that callback reaches the old, dead
+ * instance; reacting to the store empties the form of whichever instance is mounted.
+ */
+export function useOnTradeDraftCleared(market: Market, section: TradeDraftSection, onCleared: () => void) {
+  const key = getTradeDraftKey(market.chainId, market.id);
+  const isCleared = useTradeFormDraft((state) => state.drafts[key]?.[section] === undefined);
+
+  const onClearedRef = useRef(onCleared);
+  onClearedRef.current = onCleared;
+  // Only the transition counts: a panel mounting with no draft has nothing to empty.
+  const wasClearedRef = useRef(isCleared);
+
+  useEffect(() => {
+    if (isCleared && !wasClearedRef.current) {
+      onClearedRef.current();
+    }
+    wasClearedRef.current = isCleared;
+  }, [isCleared]);
 }
 
 /** The stored order type for this market, sanitized against what the market offers. */

--- a/web/src/lib/trade-draft.test.ts
+++ b/web/src/lib/trade-draft.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  type TradeDrafts,
+  applyTradeDraft,
+  getTradeDraftKey,
+  isDraftForOutcome,
+  readOrderType,
+  removeTradeDraft,
+} from "./trade-draft";
+
+const KEY = getTradeDraftKey(100, "0xABC");
+const OUTCOME = "0x1111111111111111111111111111111111111111";
+
+describe("getTradeDraftKey", () => {
+  it("is case insensitive on the market id", () => {
+    expect(getTradeDraftKey(100, "0xABC")).toBe(getTradeDraftKey(100, "0xabc"));
+  });
+
+  it("keeps drafts of the same market on different chains apart", () => {
+    expect(getTradeDraftKey(100, "0xabc")).not.toBe(getTradeDraftKey(1, "0xabc"));
+  });
+});
+
+describe("applyTradeDraft", () => {
+  it("merges section by section, leaving the other sections alone", () => {
+    let drafts: TradeDrafts = {};
+    drafts = applyTradeDraft(drafts, KEY, { orderType: "limit" });
+    drafts = applyTradeDraft(drafts, KEY, { limit: { outcomeToken: OUTCOME, limitPrice: "0.86" } });
+
+    expect(drafts[KEY]).toEqual({ orderType: "limit", limit: { outcomeToken: OUTCOME, limitPrice: "0.86" } });
+  });
+
+  it("replaces a section wholesale rather than deep merging it", () => {
+    let drafts = applyTradeDraft({}, KEY, { fillToEstimate: { targetEstimate: "120", maxCollateralToUse: "50" } });
+    drafts = applyTradeDraft(drafts, KEY, { fillToEstimate: { targetEstimate: "130", maxCollateralToUse: "" } });
+
+    expect(drafts[KEY].fillToEstimate).toEqual({ targetEstimate: "130", maxCollateralToUse: "" });
+  });
+
+  it("does not mutate the drafts it is given", () => {
+    const drafts: TradeDrafts = { [KEY]: { orderType: "market" } };
+    applyTradeDraft(drafts, KEY, { orderType: "limit" });
+
+    expect(drafts[KEY].orderType).toBe("market");
+  });
+
+  it("drops the least recently written markets past the cap", () => {
+    let drafts: TradeDrafts = {};
+    for (const marketId of ["0x1", "0x2", "0x3"]) {
+      drafts = applyTradeDraft(drafts, getTradeDraftKey(100, marketId), { orderType: "market" }, 2);
+    }
+
+    expect(Object.keys(drafts)).toEqual([getTradeDraftKey(100, "0x2"), getTradeDraftKey(100, "0x3")]);
+  });
+
+  it("counts a rewritten market as the most recent one", () => {
+    let drafts: TradeDrafts = {};
+    for (const marketId of ["0x1", "0x2"]) {
+      drafts = applyTradeDraft(drafts, getTradeDraftKey(100, marketId), { orderType: "market" }, 2);
+    }
+    drafts = applyTradeDraft(drafts, getTradeDraftKey(100, "0x1"), { orderType: "limit" }, 2);
+    drafts = applyTradeDraft(drafts, getTradeDraftKey(100, "0x3"), { orderType: "market" }, 2);
+
+    expect(Object.keys(drafts)).toEqual([getTradeDraftKey(100, "0x1"), getTradeDraftKey(100, "0x3")]);
+  });
+});
+
+describe("removeTradeDraft", () => {
+  it("removes only the given market", () => {
+    const other = getTradeDraftKey(100, "0xdef");
+    const drafts: TradeDrafts = { [KEY]: { orderType: "limit" }, [other]: { orderType: "market" } };
+
+    expect(removeTradeDraft(drafts, KEY)).toEqual({ [other]: { orderType: "market" } });
+  });
+
+  it("returns the same object when there is nothing to remove", () => {
+    const drafts: TradeDrafts = { [KEY]: { orderType: "limit" } };
+
+    expect(removeTradeDraft(drafts, "missing")).toBe(drafts);
+  });
+});
+
+describe("isDraftForOutcome", () => {
+  it("matches the outcome the draft was typed against, whatever the casing", () => {
+    expect(isDraftForOutcome({ outcomeToken: OUTCOME.toUpperCase() }, OUTCOME)).toBe(true);
+  });
+
+  it("rejects a draft from another outcome, and a missing draft", () => {
+    expect(isDraftForOutcome({ outcomeToken: OUTCOME }, "0x2222222222222222222222222222222222222222")).toBe(false);
+    expect(isDraftForOutcome(undefined, OUTCOME)).toBe(false);
+  });
+});
+
+describe("readOrderType", () => {
+  it("defaults to market without a stored draft", () => {
+    expect(readOrderType(undefined, { isGeneric: true, allowFillToEstimate: true })).toBe("market");
+  });
+
+  it("returns the stored order type when the market still offers it", () => {
+    expect(readOrderType("limit", { isGeneric: true, allowFillToEstimate: false })).toBe("limit");
+    expect(readOrderType("fill-to-estimate", { isGeneric: true, allowFillToEstimate: true })).toBe("fill-to-estimate");
+  });
+
+  it("falls back to market on non-Generic markets, which are market-order only", () => {
+    expect(readOrderType("limit", { isGeneric: false, allowFillToEstimate: true })).toBe("market");
+  });
+
+  it("falls back to market when fill-to-estimate is not available here", () => {
+    expect(readOrderType("fill-to-estimate", { isGeneric: true, allowFillToEstimate: false })).toBe("market");
+  });
+});

--- a/web/src/lib/trade-draft.test.ts
+++ b/web/src/lib/trade-draft.test.ts
@@ -1,12 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  type TradeDrafts,
-  applyTradeDraft,
-  getTradeDraftKey,
-  isDraftForOutcome,
-  readOrderType,
-  removeTradeDraft,
-} from "./trade-draft";
+import { type TradeDrafts, applyTradeDraft, getTradeDraftKey, isDraftForOutcome, readOrderType } from "./trade-draft";
 
 const KEY = getTradeDraftKey(100, "0xABC");
 const OUTCOME = "0x1111111111111111111111111111111111111111";
@@ -62,21 +55,6 @@ describe("applyTradeDraft", () => {
     drafts = applyTradeDraft(drafts, getTradeDraftKey(100, "0x3"), { orderType: "market" }, 2);
 
     expect(Object.keys(drafts)).toEqual([getTradeDraftKey(100, "0x1"), getTradeDraftKey(100, "0x3")]);
-  });
-});
-
-describe("removeTradeDraft", () => {
-  it("removes only the given market", () => {
-    const other = getTradeDraftKey(100, "0xdef");
-    const drafts: TradeDrafts = { [KEY]: { orderType: "limit" }, [other]: { orderType: "market" } };
-
-    expect(removeTradeDraft(drafts, KEY)).toEqual({ [other]: { orderType: "market" } });
-  });
-
-  it("returns the same object when there is nothing to remove", () => {
-    const drafts: TradeDrafts = { [KEY]: { orderType: "limit" } };
-
-    expect(removeTradeDraft(drafts, "missing")).toBe(drafts);
   });
 });
 

--- a/web/src/lib/trade-draft.test.ts
+++ b/web/src/lib/trade-draft.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { type TradeDrafts, applyTradeDraft, getTradeDraftKey, isDraftForOutcome, readOrderType } from "./trade-draft";
+import {
+  type TradeDrafts,
+  applyTradeDraft,
+  clearTradeDraftSection,
+  getTradeDraftKey,
+  isDraftForOutcome,
+  readOrderType,
+} from "./trade-draft";
 
 const KEY = getTradeDraftKey(100, "0xABC");
 const OUTCOME = "0x1111111111111111111111111111111111111111";
@@ -55,6 +62,29 @@ describe("applyTradeDraft", () => {
     drafts = applyTradeDraft(drafts, getTradeDraftKey(100, "0x3"), { orderType: "market" }, 2);
 
     expect(Object.keys(drafts)).toEqual([getTradeDraftKey(100, "0x1"), getTradeDraftKey(100, "0x3")]);
+  });
+});
+
+describe("clearTradeDraftSection", () => {
+  it("drops only that section and keeps the order type", () => {
+    const drafts: TradeDrafts = {
+      [KEY]: {
+        orderType: "limit",
+        limit: { outcomeToken: OUTCOME, limitPrice: "0.5" },
+        fillToEstimate: { targetEstimate: "10", maxCollateralToUse: "1" },
+      },
+    };
+
+    expect(clearTradeDraftSection(drafts, KEY, "limit")).toEqual({
+      [KEY]: { orderType: "limit", fillToEstimate: { targetEstimate: "10", maxCollateralToUse: "1" } },
+    });
+  });
+
+  it("returns the same object when there is nothing to remove", () => {
+    const drafts: TradeDrafts = { [KEY]: { orderType: "limit" } };
+
+    expect(clearTradeDraftSection(drafts, KEY, "market")).toBe(drafts);
+    expect(clearTradeDraftSection(drafts, "missing", "market")).toBe(drafts);
   });
 });
 

--- a/web/src/lib/trade-draft.ts
+++ b/web/src/lib/trade-draft.ts
@@ -1,0 +1,109 @@
+import type { TradeType } from "@seer-pm/sdk";
+
+/** Order types offered by the trade widget's order-type dropdown. */
+export type SwapOrderType = "market" | "limit" | "fill-to-estimate";
+
+export interface MarketDraft {
+  /** Outcome the amounts belong to; a draft is dropped when the selected outcome moved on. */
+  outcomeToken: string;
+  swapType: "buy" | "sell";
+  tradeType: TradeType;
+  amount: string;
+  amountOut: string;
+}
+
+export interface LimitDraft {
+  /** Outcome the target price belongs to; a draft is dropped when the selected outcome moved on. */
+  outcomeToken: string;
+  /** Only the target price: the fill-to-price amounts are derived from it and from pool liquidity. */
+  limitPrice: string;
+}
+
+export interface FillToEstimateDraft {
+  targetEstimate: string;
+  maxCollateralToUse: string;
+}
+
+/** What the user typed in one market's trade widget, kept across unmounts. */
+export interface TradeDraft {
+  orderType?: SwapOrderType;
+  market?: MarketDraft;
+  limit?: LimitDraft;
+  fillToEstimate?: FillToEstimateDraft;
+}
+
+export type TradeDrafts = Record<string, TradeDraft>;
+
+/** Drafts are per market; keep only the last few so session storage cannot grow without bound. */
+export const MAX_TRADE_DRAFTS = 5;
+
+export function getTradeDraftKey(chainId: number, marketId: string): string {
+  return `${chainId}-${marketId.toLowerCase()}`;
+}
+
+/**
+ * Merge `patch` into the draft for `key`, section by section, and keep only the
+ * `maxEntries` most recently written markets. The written key is always reinserted
+ * last, so it counts as the most recent one.
+ */
+export function applyTradeDraft(
+  drafts: TradeDrafts,
+  key: string,
+  patch: TradeDraft,
+  maxEntries = MAX_TRADE_DRAFTS,
+): TradeDrafts {
+  const merged: TradeDrafts = {};
+
+  for (const [draftKey, draft] of Object.entries(drafts)) {
+    if (draftKey !== key) {
+      merged[draftKey] = draft;
+    }
+  }
+  merged[key] = { ...drafts[key], ...patch };
+
+  const keys = Object.keys(merged);
+  if (keys.length <= maxEntries) {
+    return merged;
+  }
+
+  const pruned: TradeDrafts = {};
+  for (const draftKey of keys.slice(keys.length - maxEntries)) {
+    pruned[draftKey] = merged[draftKey];
+  }
+  return pruned;
+}
+
+export function removeTradeDraft(drafts: TradeDrafts, key: string): TradeDrafts {
+  if (!(key in drafts)) {
+    return drafts;
+  }
+  const next: TradeDrafts = {};
+  for (const [draftKey, draft] of Object.entries(drafts)) {
+    if (draftKey !== key) {
+      next[draftKey] = draft;
+    }
+  }
+  return next;
+}
+
+/** A draft only applies to the outcome it was typed against. */
+export function isDraftForOutcome(draft: { outcomeToken: string } | undefined, outcomeTokenAddress: string): boolean {
+  return draft?.outcomeToken.toLowerCase() === outcomeTokenAddress.toLowerCase();
+}
+
+/**
+ * A stored order type is only valid while the market still offers it: non-Generic
+ * markets are market-order only, and fill-to-estimate is limited to scalar markets.
+ */
+export function readOrderType(
+  orderType: SwapOrderType | undefined,
+  { isGeneric, allowFillToEstimate }: { isGeneric: boolean; allowFillToEstimate: boolean },
+): SwapOrderType {
+  if (!orderType || !isGeneric) {
+    return "market";
+  }
+  if (orderType === "fill-to-estimate" && !allowFillToEstimate) {
+    return "market";
+  }
+  return orderType;
+}

--- a/web/src/lib/trade-draft.ts
+++ b/web/src/lib/trade-draft.ts
@@ -34,6 +34,9 @@ export interface TradeDraft {
 
 export type TradeDrafts = Record<string, TradeDraft>;
 
+/** The panel-owned parts of a draft; the order type is not one of them. */
+export type TradeDraftSection = "market" | "limit" | "fillToEstimate";
+
 /** Drafts are per market; keep only the last few so session storage cannot grow without bound. */
 export const MAX_TRADE_DRAFTS = 5;
 
@@ -71,6 +74,19 @@ export function applyTradeDraft(
     pruned[draftKey] = merged[draftKey];
   }
   return pruned;
+}
+
+/**
+ * Drop one panel's section of the draft for `key`, keeping the order type and the
+ * other panels' sections. Returns the same object when there is nothing to remove.
+ */
+export function clearTradeDraftSection(drafts: TradeDrafts, key: string, section: TradeDraftSection): TradeDrafts {
+  const draft = drafts[key];
+  if (!draft || !(section in draft)) {
+    return drafts;
+  }
+  const { [section]: _removed, ...rest } = draft;
+  return { ...drafts, [key]: rest };
 }
 
 /** A draft only applies to the outcome it was typed against. */

--- a/web/src/lib/trade-draft.ts
+++ b/web/src/lib/trade-draft.ts
@@ -73,19 +73,6 @@ export function applyTradeDraft(
   return pruned;
 }
 
-export function removeTradeDraft(drafts: TradeDrafts, key: string): TradeDrafts {
-  if (!(key in drafts)) {
-    return drafts;
-  }
-  const next: TradeDrafts = {};
-  for (const [draftKey, draft] of Object.entries(drafts)) {
-    if (draftKey !== key) {
-      next[draftKey] = draft;
-    }
-  }
-  return next;
-}
-
 /** A draft only applies to the outcome it was typed against. */
 export function isDraftForOutcome(draft: { outcomeToken: string } | undefined, outcomeTokenAddress: string): boolean {
   return draft?.outcomeToken.toLowerCase() === outcomeTokenAddress.toLowerCase();


### PR DESCRIPTION
Each order type in the trade widget renders its own panel, and each panel owns its own useForm and useState. So switching Market <-> Fill-to-price <-> Fill-to-estimate destroys every amount and target price the user typed, and the order type itself falls back to "market" as soon as the widget unmounts. Opening the max slippage screen does the same, since it replaces the form rather than hiding it, and so does SwapWidget returning null while the outcome token reloads.

That last one is where it hurts: the report that prompted this is a user losing the amount between the approve and the swap, which is exactly when an unmount is most expensive. The approve itself is not the culprit -- useApproveTokens.onSuccess only invalidates ["useMissingApprovals"], which remounts the button subtree and leaves the form alone -- so the fix is to stop keeping the values in a place an unmount can take away.

Add a per-market draft in session storage (zustand + persist, the pattern useGlobalState already uses; session rather than local, so a draft outlives a reload of the tab but not the tab). The panels seed their defaults from it once, write back on every change, and clear it when the trade goes through. A draft is keyed by chain + market and pruned to the five most recently written markets.

Three things had to change so restoring actually holds:

- The reset effects also run on mount, so they were wiping the draft they had just restored. They now compare the traded pair against a ref and do nothing on the first run; the real reset on an outcome, collateral or direction change is untouched. Same for the quote effect, which blanked amountOut before the first quote landed.
- reset() and resetField() restore the *default* value, which is now the draft. They pass explicit empty values instead, or the amount just traded would come straight back.
- A restored amount is not dirty, so the balance effect never validated it and the Swap button stayed disabled until the field was touched. It now validates on value rather than on dirtiness, once the balance is known.

The market and fill-to-price drafts record the outcome token they were typed against and are dropped when it no longer matches, so an amount can never be restored onto a different outcome. Fill-to-price keeps only the target price: its amounts are derived from it and from pool liquidity, and they refill themselves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trade widgets now preserve entered values, selected order types, and trade settings when switching views or reloading the page within the same session.
  * Saved values are restored only when they match the selected market and outcome.
  * Up to five recent market drafts are retained.

* **Bug Fixes**
  * Forms now fully clear after successful trades and when trading pairs change.
  * Restored values are revalidated and incompatible order types are safely adjusted.
  * Draft data is cleared appropriately after completed trades.
  * Trade values and potential returns now use more consistent number formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->